### PR TITLE
[aop] Evaluating the strategy with a context

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/ContextLocation.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/ContextLocation.java
@@ -1,0 +1,25 @@
+package org.ff4j.aop;
+
+/**
+ * Enumeration that represents the location of the flipping context execution
+ * which will be passed to the flipping strategy.
+ *
+ * {@see Flip} annotation
+ * {@see FlippingExecutionContext}
+ */
+public enum ContextLocation {
+    /**
+     * {@link Flip} will not use a {@link org.ff4j.core.FlippingExecutionContext} to switch the feature.
+     */
+    NONE,
+
+    /**
+     * {@link Flip} will use the first method parameter that is an instance of {@link org.ff4j.core.FlippingExecutionContext}.
+     */
+    PARAMETER,
+
+    /**
+     * {@link Flip} will use the {@link org.ff4j.FF4j} instance to retrieve the current context.
+     */
+    FF4J
+}

--- a/ff4j-aop/src/main/java/org/ff4j/aop/Flip.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/Flip.java
@@ -47,6 +47,13 @@ public @interface Flip {
     Class<?> strategy() default NullType.class;
 
     /**
+     * Location of the flipping execution context.
+     *
+     * @return flippinf execution context location
+     */
+    ContextLocation contextLocation() default ContextLocation.NONE;
+
+    /**
      * Set implementation clazz to be used.
      * 
      * @return mock java class

--- a/ff4j-aop/src/test/java/org/ff4j/aop/ContextService.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/ContextService.java
@@ -1,0 +1,13 @@
+package org.ff4j.aop;
+
+import org.ff4j.core.FlippingExecutionContext;
+
+public interface ContextService {
+    @Flip(name = "context-french", alterBean = "context.french",
+            strategy = ContextStrategy.class, contextLocation = ContextLocation.FF4J)
+    String sayHelloWithThreadLocal(String name);
+
+    @Flip(name = "context-french", alterBean = "context.french",
+            strategy = ContextStrategy.class, contextLocation = ContextLocation.PARAMETER)
+    String sayHelloWithParameter(String name, FlippingExecutionContext context);
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/ContextServiceEnglishImpl.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/ContextServiceEnglishImpl.java
@@ -1,0 +1,17 @@
+package org.ff4j.aop;
+
+import org.ff4j.core.FlippingExecutionContext;
+import org.springframework.stereotype.Component;
+
+@Component("context.english")
+public class ContextServiceEnglishImpl implements ContextService {
+    @Override
+    public String sayHelloWithThreadLocal(String name) {
+        return "Hello " + name;
+    }
+
+    @Override
+    public String sayHelloWithParameter(String name, FlippingExecutionContext context) {
+        return "Hello " + name;
+    }
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/ContextServiceFrenchImpl.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/ContextServiceFrenchImpl.java
@@ -1,0 +1,17 @@
+package org.ff4j.aop;
+
+import org.ff4j.core.FlippingExecutionContext;
+import org.springframework.stereotype.Component;
+
+@Component("context.french")
+public class ContextServiceFrenchImpl implements ContextService {
+    @Override
+    public String sayHelloWithThreadLocal(String name) {
+        return "Bonjour " + name;
+    }
+
+    @Override
+    public String sayHelloWithParameter(String name, FlippingExecutionContext context) {
+        return "Bonjour " + name;
+    }
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/ContextStrategy.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/ContextStrategy.java
@@ -1,0 +1,12 @@
+package org.ff4j.aop;
+
+import org.ff4j.core.FeatureStore;
+import org.ff4j.core.FlippingExecutionContext;
+import org.ff4j.strategy.AbstractFlipStrategy;
+
+public class ContextStrategy extends AbstractFlipStrategy {
+    @Override
+    public boolean evaluate(String featureName, FeatureStore store, FlippingExecutionContext executionContext) {
+        return executionContext != null && "french".equals(executionContext.getString("user.settings.language", true));
+    }
+}

--- a/ff4j-aop/src/test/java/org/ff4j/aop/FeatureFlippingThoughAopTest.java
+++ b/ff4j-aop/src/test/java/org/ff4j/aop/FeatureFlippingThoughAopTest.java
@@ -20,6 +20,7 @@ package org.ff4j.aop;
  * #L%
  */
 
+import org.ff4j.core.FlippingExecutionContext;
 import org.junit.Assert;
 
 import org.ff4j.FF4j;
@@ -41,11 +42,43 @@ public class FeatureFlippingThoughAopTest {
     @Qualifier("greeting.english")
     private GreetingService greeting;
 
+    @Autowired
+    @Qualifier("context.english")
+    private ContextService context;
+
     @Test
     public void testAOP() {
         Assert.assertTrue(greeting.sayHello("CLU").startsWith("Hello"));
         ff4j.enable("language-french");
         Assert.assertTrue(greeting.sayHello("CLU").startsWith("Bonjour"));
+    }
+
+    @Test
+    public void testAOPWithParameter() {
+        ff4j.enable("context-french");
+
+        Assert.assertTrue(context.sayHelloWithParameter("CLU", null).startsWith("Hello"));
+
+        FlippingExecutionContext executionContext = new FlippingExecutionContext();
+
+        executionContext.putString("user.settings.language", "english");
+        Assert.assertTrue(context.sayHelloWithParameter("CLU", executionContext).startsWith("Hello"));
+
+        executionContext.putString("user.settings.language", "french");
+        Assert.assertTrue(context.sayHelloWithParameter("CLU", executionContext).startsWith("Bonjour"));
+    }
+
+    @Test
+    public void testAOPWithThreadLocal() {
+        ff4j.enable("context-french");
+
+        FlippingExecutionContext executionContext = ff4j.getCurrentContext();
+
+        executionContext.putString("user.settings.language", "english");
+        Assert.assertTrue(context.sayHelloWithThreadLocal("CLU").startsWith("Hello"));
+
+        executionContext.putString("user.settings.language", "french");
+        Assert.assertTrue(context.sayHelloWithThreadLocal("CLU").startsWith("Bonjour"));
     }
 
 }

--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -91,7 +91,8 @@ public class FF4j {
     /** Event Publisher. */
     private EventPublisher eventPublisher = null;
     
-    
+    private ThreadLocal<FlippingExecutionContext> currentExecutionContext = new ThreadLocal<FlippingExecutionContext>();
+
     public void setFileName(String f) {}
 
     /**
@@ -594,4 +595,16 @@ public class FF4j {
         this.pStore = pStore;
     }
 
+    public FlippingExecutionContext getCurrentContext() {
+        FlippingExecutionContext context = this.currentExecutionContext.get();
+        if (context == null) {
+            context = new FlippingExecutionContext();
+            this.currentExecutionContext.set(context);
+        }
+        return context;
+    }
+
+    public void removeCurrentContext() {
+        this.currentExecutionContext.remove();
+    }
 }


### PR DESCRIPTION
@Flip annotation has a new argument to specify if the strategy evaluation needs a context, the values are:
- NONE: the strategy does not need context
- FF4J: the strategy will use a context stored in a ThreadLocal
- PARAMETER: the context is retrieved from the argument method, so the developer is free/responsible to pass the correct context (usefull to be thead-independant), or can reuse it to call a nested 'check'