### PR TITLE
Allow customisation of event publisher

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -536,6 +536,16 @@ public class FF4j {
     }
 
     /**
+     * Setter accessor for attribute 'eventPublisher'.
+     *
+     * @param eventPublisher
+     *            new value for 'eventPublisher '
+     */
+    public void setEventPublisher(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
      * Getter accessor for attribute 'eventPublisher'.
      * 
      * @return current value of 'eventPublisher'


### PR DESCRIPTION
Currently there is no setter on FF4j to allow setting a customised
event publisher. Additionally, I have added constructors to allow
customising the executor used in the publisher and changing the
wait-time non-statically.