### PR TITLE
Do not rename current thread from EventPublisher

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/EventWorker.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventWorker.java
@@ -59,7 +59,6 @@ public class EventWorker implements Callable<Boolean> {
         this.eventRepository = repo;
         if (e != null) {
             this.name = e.toThreadName();
-            Thread.currentThread().setName("FF4J Monitoring worker processing " + name);
         }
     }
 


### PR DESCRIPTION
This currently overwrites the thread name for the thread calling
EventPublisher.publish()

closes #54