### PR TITLE
Add shutdown methods to FF4J/EventPublisher

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -94,6 +94,8 @@ public class FF4j {
     /** Event Publisher (threadpool, executor) to send data into {@link EventRepository} */
     private EventPublisher eventPublisher = null;
     
+    private volatile boolean shutdownEventPublisher;
+
     /** Hold flipping execution context as Thread-safe data. */
     private ThreadLocal<FlippingExecutionContext> currentExecutionContext = new ThreadLocal<FlippingExecutionContext>();
    
@@ -555,8 +557,10 @@ public class FF4j {
      * @return current value of 'eventPublisher'
      */
     public EventPublisher getEventPublisher() {
+        // TODO: this is not thread-safe
         if (eventPublisher == null) {
             eventPublisher = new EventPublisher(eventRepository);
+            this.shutdownEventPublisher = true;
         }
         return eventPublisher;
     }
@@ -647,4 +651,14 @@ public class FF4j {
      *      target name
      */
     public void setFileName(String fname) { }
+
+    /**
+     * Shuts down the event publisher if we actually started it (As opposed to
+     * having it dependency-injected).
+     */
+    public void stop() {
+        if (this.eventPublisher != null && this.shutdownEventPublisher) {
+            this.eventPublisher.stop();
+        }
+    }
 }

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
@@ -58,6 +58,8 @@ public class EventPublisher {
     /** the amount of time to wait after submitting for the task to complete. */
     private final long submitTimeout;
 
+    private final boolean shutdownExecutor;
+
     /**
      * Default constructor.
      */
@@ -128,6 +130,7 @@ public class EventPublisher {
         repository = er;
 
         this.submitTimeout = submitTimeout;
+        this.shutdownExecutor = true;
     }
 
     /**
@@ -147,6 +150,7 @@ public class EventPublisher {
         repository = er;
         executor = executorService;
         this.submitTimeout = submitTimeout;
+        this.shutdownExecutor = false;
     }
 
     /**
@@ -180,7 +184,7 @@ public class EventPublisher {
     }
 
     /**
-     * Paramterized constructor.
+     * Parameterized constructor.
      * 
      * @param featureName
      *            target feature name
@@ -193,6 +197,18 @@ public class EventPublisher {
             evt.setType(EventType.FEATURE_CHECK_OFF);
         }
         publish(evt);
+    }
+
+    /**
+     * Stops the event publisher. If we started an executor service, it will
+     * be shutdown here.
+     */
+    public void stop() {
+        if (!this.shutdownExecutor) {
+            return;
+        }
+
+        this.executor.shutdownNow();
     }
 
     /**


### PR DESCRIPTION
This allows explicitly stopping the executor service
which is started for the event publishing.

closes #58