### PR TITLE
suppression de l'utilisation de l'interface ParameterizedRowMapper

### DIFF
--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/FeatureRowMapper.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/FeatureRowMapper.java
@@ -28,14 +28,14 @@ import org.ff4j.core.FlippingStrategy;
 import org.ff4j.exception.FeatureAccessException;
 import org.ff4j.store.JdbcStoreConstants;
 import org.ff4j.utils.ParameterUtils;
-import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
+import org.springframework.jdbc.core.RowMapper;
 
 /**
  * Mapper to convert result into
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureRowMapper implements ParameterizedRowMapper<Feature>, JdbcStoreConstants {
+public class FeatureRowMapper implements RowMapper<Feature>, JdbcStoreConstants {
 
     /** {@inheritDoc} */
     @Override

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/RoleRowMapper.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/RoleRowMapper.java
@@ -28,14 +28,14 @@ import java.util.Map;
 import java.util.Set;
 
 import org.ff4j.store.JdbcStoreConstants;
-import org.springframework.jdbc.core.simple.ParameterizedRowMapper;
+import org.springframework.jdbc.core.RowMapper;
 
 /**
  * Implementation of JDBC store using Spring JDBC.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class RoleRowMapper implements ParameterizedRowMapper<Integer>, JdbcStoreConstants {
+public class RoleRowMapper implements RowMapper<Integer>, JdbcStoreConstants {
 
     /** Default Row Mapper to get groups. */
     private final Map<String, Set<String>> roles = new HashMap<String, Set<String>>();


### PR DESCRIPTION
L'interface ParameterizedRowMapper est déprécié dans spring 4.1 et supprimé dans spring 4.2 et a été créée à l'époque de spring 3 quand les generics n'éxistaient pas encore