### PR TITLE
squid:S2153 - Boxing and unboxing should not be immediately reversed

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/spring/autowire/AutowiredFF4JBeanPostProcessor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/autowire/AutowiredFF4JBeanPostProcessor.java
@@ -111,35 +111,35 @@ public class AutowiredFF4JBeanPostProcessor implements BeanPostProcessor {
             } else if (property.parameterizedType().equals(Integer.class) 
                     && field.getType().equals(int.class) && (null != property.getValue())) {
                 // Autoboxing Integer -> Int
-                injectValue(field, bean, propertyName, ((Integer) property.getValue()).intValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else if (property.parameterizedType().equals(Long.class) 
                     && field.getType().equals(long.class) && (null != property.getValue())) {
                 // Autoboxing Long -> long
-                injectValue(field, bean, propertyName, ((Long) property.getValue()).longValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else if (property.parameterizedType().equals(Double.class) 
                     && field.getType().equals(double.class) && (null != property.getValue())) {
                 // Autoboxing Double -> double
-                injectValue(field, bean, propertyName, ((Double) property.getValue()).doubleValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else if (property.parameterizedType().equals(Byte.class) 
                     && field.getType().equals(byte.class) && (null != property.getValue())) {
                 // Autoboxing Byte -> byte
-                injectValue(field, bean, propertyName, ((Byte) property.getValue()).byteValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else if (property.parameterizedType().equals(Boolean.class) 
                     && field.getType().equals(boolean.class) && (null != property.getValue())) {
                 // Autoboxing Boolean -> boolean
-                injectValue(field, bean, propertyName, ((Boolean) property.getValue()).booleanValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else if (property.parameterizedType().equals(Short.class) 
                     && field.getType().equals(short.class) && (null != property.getValue())) {
                 // Autoboxing Short -> short
-                injectValue(field, bean, propertyName, ((Short) property.getValue()).shortValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else if (property.parameterizedType().equals(Character.class) 
                     && field.getType().equals(char.class) && (null != property.getValue())) {
                 // Autoboxing Character -> char
-                injectValue(field, bean, propertyName,((Character) property.getValue()).charValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else if (property.parameterizedType().equals(Float.class) 
                     && field.getType().equals(float.class) && (null != property.getValue())) {
                 // Autoboxing Float -> float
-                injectValue(field, bean, propertyName, ((Float) property.getValue()).floatValue());
+                injectValue(field, bean, propertyName, property.getValue());
             } else {
                 throw new IllegalArgumentException("Field annotated with @AutowiredFF4JProperty"
                             + " must inherit from org.ff4j.property.AbstractProperty or be of type " + 

--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -545,13 +545,13 @@ public class FF4j {
         StringBuilder sb = new StringBuilder("{");
         // Render Uptime as String "X day(s) X hours(s) X minute(s) X seconds"
         long uptime = System.currentTimeMillis() - startTime;
-        long daynumber = new Double(Math.floor(uptime / (1000 * 3600 * 24))).longValue();
+        long daynumber = (long) Math.floor(uptime / (1000 * 3600 * 24));
         uptime = uptime - (daynumber * 1000 * 3600 * 24);
-        long hourNumber = new Double(Math.floor(uptime / (1000 * 3600))).longValue();
+        long hourNumber = (long) Math.floor(uptime / (1000 * 3600));
         uptime = uptime - (hourNumber * 1000 * 3600);
-        long minutenumber = new Double(Math.floor(uptime / (1000 * 60))).longValue();
+        long minutenumber = (long) Math.floor(uptime / (1000 * 60));
         uptime = uptime - (minutenumber * 1000 * 60);
-        long secondnumber = new Double(Math.floor(uptime / 1000)).longValue();
+        long secondnumber = (long) Math.floor(uptime / 1000);
         sb.append("\"uptime\":\"");
         sb.append(daynumber + " day(s) ");
         sb.append(hourNumber + " hours(s) ");

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/domain/FF4jStatusApiBean.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/domain/FF4jStatusApiBean.java
@@ -87,13 +87,13 @@ public final class FF4jStatusApiBean {
     public FF4jStatusApiBean(FF4j ff4j) {
         // UpTime
         long up = System.currentTimeMillis() - ff4j.getStartTime();
-        long daynumber = new Double(Math.floor(up / (1000 * 3600 * 24))).longValue();
+        long daynumber = (long) Math.floor(up / (1000 * 3600 * 24));
         up = up - (daynumber * 1000 * 3600 * 24);
-        long hourNumber = new Double(Math.floor(up / (1000 * 3600))).longValue();
+        long hourNumber = (long) Math.floor(up / (1000 * 3600));
         up = up - (hourNumber * 1000 * 3600);
-        long minutenumber = new Double(Math.floor(up / (1000 * 60))).longValue();
+        long minutenumber = (long) Math.floor(up / (1000 * 60));
         up = up - (minutenumber * 1000 * 60);
-        long secondnumber = new Double(Math.floor(up / 1000)).longValue();
+        long secondnumber = (long) Math.floor(up / 1000);
         uptime =  daynumber + " day(s) ";
         uptime += hourNumber + " hours(s) ";
         uptime += minutenumber + " minute(s) ";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2153 - Boxing and unboxing should not be immediately reversed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2153
Please let me know if you have any questions.
George Kankava