### PR TITLE
squid:S2293 - The diamond operator ("<>") should be used

### DIFF
--- a/ff4j-store-jcache/src/main/java/org/ff4j/cache/FF4jJCacheProvider.java
+++ b/ff4j-store-jcache/src/main/java/org/ff4j/cache/FF4jJCacheProvider.java
@@ -100,7 +100,7 @@ public class FF4jJCacheProvider {
      *      cache default configuration
      */
     protected MutableConfiguration< String, Feature> getFeatureCacheConfiguration() {
-        MutableConfiguration<String, Feature> featuresCacheConfig = new MutableConfiguration<String, Feature>();        
+        MutableConfiguration<String, Feature> featuresCacheConfig = new MutableConfiguration<>();        
         featuresCacheConfig.setTypes(String.class, Feature.class);
         featuresCacheConfig.setStoreByValue(true);
         featuresCacheConfig.setStatisticsEnabled(false);
@@ -116,7 +116,7 @@ public class FF4jJCacheProvider {
      */
     @SuppressWarnings("rawtypes")
     protected MutableConfiguration< String, Property> getPropertyCacheConfiguration() {
-        MutableConfiguration<String, Property> propertiesCacheConfig = new MutableConfiguration<String, Property>();        
+        MutableConfiguration<String, Property> propertiesCacheConfig = new MutableConfiguration<>();        
         propertiesCacheConfig.setTypes(String.class, Property.class);
         propertiesCacheConfig.setStoreByValue(true);
         propertiesCacheConfig.setStatisticsEnabled(false);

--- a/ff4j-store-jcache/src/main/java/org/ff4j/store/FeatureStoreJCache.java
+++ b/ff4j-store-jcache/src/main/java/org/ff4j/store/FeatureStoreJCache.java
@@ -124,7 +124,7 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     /** {@inheritDoc} */
     @Override
     public Map<String, Feature> readAll() {
-        Map<String, Feature> myMap = new HashMap<String, Feature>();
+        Map<String, Feature> myMap = new HashMap<>();
         getCacheManager().getFeaturesCache().forEach(e->myMap.put(e.getKey(), e.getValue()));
         return myMap;
     }
@@ -166,7 +166,7 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     public Map<String, Feature> readGroup(String groupName) {
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
-        Map < String, Feature > group = new HashMap<String, Feature>();
+        Map < String, Feature > group = new HashMap<>();
         for (String uid : features.keySet()) {
             if (groupName.equals(features.get(uid).getGroup())) {
                 group.put(uid, features.get(uid));
@@ -183,7 +183,7 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     public boolean existGroup(String groupName) {
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
-        Map < String, Feature > group = new HashMap<String, Feature>();
+        Map < String, Feature > group = new HashMap<>();
         for (String uid : features.keySet()) {
             if (groupName.equals(features.get(uid).getGroup())) {
                 group.put(uid, features.get(uid));
@@ -241,7 +241,7 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     @Override
     public Set<String> readAllGroups() {
         Map < String, Feature > features = readAll();
-        Set < String > groups = new HashSet<String>();
+        Set < String > groups = new HashSet<>();
         for (String uid : features.keySet()) {
             groups.add(features.get(uid).getGroup());
         }

--- a/ff4j-store-jcache/src/main/java/org/ff4j/store/PropertyStoreJCache.java
+++ b/ff4j-store-jcache/src/main/java/org/ff4j/store/PropertyStoreJCache.java
@@ -120,7 +120,7 @@ public class PropertyStoreJCache extends AbstractPropertyStore {
     /** {@inheritDoc} */
     @Override
     public Map<String, Property<?>> readAllProperties() {
-        Map<String, Property<?>> myMap = new HashMap<String, Property<?>>();
+        Map<String, Property<?>> myMap = new HashMap<>();
         getCacheManager().getPropertiesCache().forEach(e->myMap.put(e.getKey(), e.getValue()));
         return myMap;
     }

--- a/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsFlippingStrategy.java
+++ b/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsFlippingStrategy.java
@@ -158,7 +158,7 @@ public class FF4jDroolsFlippingStrategy extends AbstractFlipStrategy {
             
             } else if (initParams.containsKey(KEY_RULES_FILES)) {
                 String exp = initParams.get(KEY_RULES_FILES);
-                this.ruleFiles = new HashSet <String > (Arrays.asList(exp.split(",")));
+                this.ruleFiles = new HashSet <> (Arrays.asList(exp.split(",")));
                 FF4jDroolsService.initFromRulesFiles(ruleFiles);
             
             } else {

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
@@ -47,13 +47,13 @@ public class FF4JSecurityContextAuthenticationManager extends AbstractAuthorizat
                 return ((FF4jSecurityContext) sc).getUserRoles();
             }
         }
-        return new HashSet<String>();
+        return new HashSet<>();
     }
 
     /** {@inheritDoc} */
     @Override
     public Set<String> listAllPermissions() {
-        Set < String > vars = new HashSet<String>();
+        Set < String > vars = new HashSet<>();
         if (FF4jAuthenticationFilter.apiConfig != null) {
             Map < String, Set<String > > perms = FF4jAuthenticationFilter.apiConfig.getPermissions();
             for (String var : perms.keySet()) {

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/store/FeatureStoreHttp.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/store/FeatureStoreHttp.java
@@ -233,7 +233,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore implements org.ff4j.w
        
         String resEntity = (String) cRes.readEntity(String.class);
         Feature[] fArray = parseFeatureArray(resEntity);
-        Map<String, Feature> features = new HashMap<String, Feature>();
+        Map<String, Feature> features = new HashMap<>();
         for (Feature feature : fArray) {
             features.put(feature.getUid(), feature);
         }
@@ -369,7 +369,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore implements org.ff4j.w
         }
         String resEntity = cRes.readEntity(String.class);
         Feature[] fArray = parseFeatureArray(resEntity);
-        Map<String, Feature> features = new HashMap<String, Feature>();
+        Map<String, Feature> features = new HashMap<>();
         for (Feature feature : fArray) {
             features.put(feature.getUid(), feature);
         }
@@ -399,7 +399,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore implements org.ff4j.w
         if (Status.OK.getStatusCode() != cRes.getStatus()) {
             throw new FeatureAccessException("Cannot read groups, an HTTP error " + cRes.getStatus() + " occured.");
         }
-        Set < String > groupNames = new HashSet<String>();
+        Set < String > groupNames = new HashSet<>();
         for (Map <String, String > currentGroup : groupList) {
             groupNames.add(currentGroup.get("groupName"));
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2293
Please let me know if you have any questions.
George Kankava