### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
@@ -126,8 +126,8 @@ public class FeatureAdvisor implements MethodInterceptor, BeanPostProcessor, App
      * @return is param are correct
      */
     private boolean assertRequiredParams(Flip ff) {
-        boolean alterBeanPresent = (ff.alterBean() != null && !ff.alterBean().isEmpty());
-        boolean alterClazPresent = ((ff.alterClazz() != null) && (ff.alterClazz() != NullType.class));
+        boolean alterBeanPresent = ff.alterBean() != null && !ff.alterBean().isEmpty();
+        boolean alterClazPresent = (ff.alterClazz() != null) && (ff.alterClazz() != NullType.class);
         return alterBeanPresent || alterClazPresent;
     }
 
@@ -237,7 +237,7 @@ public class FeatureAdvisor implements MethodInterceptor, BeanPostProcessor, App
     }
 
     private String currentBeanName(MethodInvocation pMInvoc) {
-        Class<?> targetClass = (pMInvoc.getThis() != null ? AopUtils.getTargetClass(pMInvoc.getThis()) : null);       
+        Class<?> targetClass = pMInvoc.getThis() != null ? AopUtils.getTargetClass(pMInvoc.getThis()) : null;
         if (targetClass == null) {
             throw new IllegalArgumentException("ff4j-aop: Static methods cannot be feature flipped");
         }

--- a/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/PropertiesPlaceHolderBeanDefinitionVisitor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/PropertiesPlaceHolderBeanDefinitionVisitor.java
@@ -100,7 +100,7 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
                 if (!visitedPlaceholders.add(placeholder)) {
                     throw new BeanDefinitionStoreException("Circular placeholder reference '" + placeholder + "' in property definitions");
                 }
-                if (propertiesMap==null || !propertiesMap.containsKey((placeholder))) {
+                if (propertiesMap==null || !propertiesMap.containsKey(placeholder)) {
                     throw new PropertyNotFoundException(
                             PLACEHOLDER_PROPERTY_PREFIX + ": Cannot perform placeholding on " + placeholder);
                 }
@@ -129,7 +129,7 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
                 if (!visitedPlaceholders.add(placeholder)) {
                     throw new BeanDefinitionStoreException("Circular placeholder reference '" + placeholder + "' in property definitions");
                 }
-                if (featureMap==null || !featureMap.containsKey((placeholder))) {
+                if (featureMap==null || !featureMap.containsKey(placeholder)) {
                     throw new FeatureNotFoundException(
                             PLACEHOLDER_FEATURE_PREFIX + ": Cannot perform placeholding on " + placeholder);
                 }

--- a/ff4j-core/src/main/java/org/ff4j/cache/FF4jCacheProxy.java
+++ b/ff4j-core/src/main/java/org/ff4j/cache/FF4jCacheProxy.java
@@ -333,7 +333,7 @@ public class FF4jCacheProxy implements FeatureStore, PropertyStore {
     @Override
     public boolean isEmpty() {
         Set<String> pNames = listPropertyNames();
-        return (pNames != null && pNames.size() > 0);
+        return pNames != null && pNames.size() > 0;
     }
 
     /** {@inheritDoc} */

--- a/ff4j-core/src/main/java/org/ff4j/cache/InMemoryCacheEntry.java
+++ b/ff4j-core/src/main/java/org/ff4j/cache/InMemoryCacheEntry.java
@@ -77,7 +77,7 @@ public final class InMemoryCacheEntry<T> implements Serializable {
      *      time to live
      */
     public boolean hasReachTimeToLive() {
-        return ((System.currentTimeMillis() - getInsertedDate()) >= (TO_MILLIS * timeToLive));
+        return (System.currentTimeMillis() - getInsertedDate()) >= (TO_MILLIS * timeToLive);
     }
 
     /**

--- a/ff4j-core/src/main/java/org/ff4j/property/Property.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/Property.java
@@ -156,7 +156,7 @@ public abstract class Property < T > implements Serializable {
      */
     @SuppressWarnings({ "unchecked" })
     public Class<T> parameterizedType() {
-        ParameterizedType pt = ((ParameterizedType) getClass().getGenericSuperclass());
+        ParameterizedType pt = (ParameterizedType) getClass().getGenericSuperclass();
         return  (Class<T>) pt.getActualTypeArguments()[0];
     }
     

--- a/ff4j-core/src/main/java/org/ff4j/property/store/AbstractPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/AbstractPropertyStore.java
@@ -68,7 +68,7 @@ public abstract class AbstractPropertyStore implements PropertyStore {
     /** {@inheritDoc} */
     public boolean isEmpty() {
         Set < String > pNames = listPropertyNames();
-        return (pNames == null || pNames.size() == 0);
+        return pNames == null || pNames.size() == 0;
     }
     
     /** {@inheritDoc} */

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -558,7 +558,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             ps.setString(1, groupName);
             rs = ps.executeQuery();
             rs.next(); 
-            return (rs.getInt(1) > 0);
+            return rs.getInt(1) > 0;
         } catch (SQLException sqlEX) {
             throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
         } finally {

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/store/FeatureStoreEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/store/FeatureStoreEhCache.java
@@ -74,7 +74,7 @@ public class FeatureStoreEhCache extends AbstractFeatureStore implements FF4JEhC
     @Override
     public boolean exist(String uid) {
         Util.assertParamNotNull(uid, "Feature identifier");
-        return (getCache().get(uid) != null);
+        return getCache().get(uid) != null;
     }
     
     /** {@inheritDoc} */

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/store/PropertyStoreEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/store/PropertyStoreEhCache.java
@@ -72,7 +72,7 @@ public class PropertyStoreEhCache extends AbstractPropertyStore {
     @Override
     public boolean existProperty(String name) {
         Util.assertParamNotNull(name, "Property name");
-        return  (wrapper.getCacheProperties().get(name) != null);
+        return wrapper.getCacheProperties().get(name) != null;
     }
 
     /** {@inheritDoc} */

--- a/ff4j-store-jcache/src/main/java/org/ff4j/store/FeatureStoreJCache.java
+++ b/ff4j-store-jcache/src/main/java/org/ff4j/store/FeatureStoreJCache.java
@@ -63,7 +63,7 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     @Override
     public boolean exist(String uid) {
         Util.assertParamNotNull(uid, "Feature identifier");
-        return (getCacheManager().getFeature(uid) != null);
+        return getCacheManager().getFeature(uid) != null;
     }
     
     /** {@inheritDoc} */

--- a/ff4j-store-jcache/src/main/java/org/ff4j/store/PropertyStoreJCache.java
+++ b/ff4j-store-jcache/src/main/java/org/ff4j/store/PropertyStoreJCache.java
@@ -64,7 +64,7 @@ public class PropertyStoreJCache extends AbstractPropertyStore {
     @Override
     public boolean existProperty(String name) {
         Util.assertParamNotNull(name, "Property name");
-        return (getCacheManager().getProperty(name) != null);
+        return getCacheManager().getProperty(name) != null;
     }
 
     /** {@inheritDoc} */

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
@@ -159,9 +159,9 @@ public final class FeatureDocumentMapper implements FeatureStoreMongoConstants {
     private Property< ? > mapProperty(DBObject dbObject) {
         PropertyJsonBean pf = new PropertyJsonBean();
         pf.setName((String) dbObject.get("name"));
-        pf.setDescription(((String) dbObject.get("description")));
-        pf.setType(((String) dbObject.get("type")));
-        pf.setValue(((String) dbObject.get("value")));
+        pf.setDescription((String) dbObject.get("description"));
+        pf.setType((String) dbObject.get("type"));
+        pf.setValue((String) dbObject.get("value"));
         if (dbObject.containsField("fixedValues")) {
             BasicDBList dbList = (BasicDBList) dbObject.get("fixedValues");
             if (dbList != null) {

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectMapper.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectMapper.java
@@ -159,9 +159,9 @@ public final class FeatureDBObjectMapper implements FeatureStoreMongoConstants {
     private Property< ? > mapProperty(DBObject dbObject) {
         PropertyJsonBean pf = new PropertyJsonBean();
         pf.setName((String) dbObject.get("name"));
-        pf.setDescription(((String) dbObject.get("description")));
-        pf.setType(((String) dbObject.get("type")));
-        pf.setValue(((String) dbObject.get("value")));
+        pf.setDescription((String) dbObject.get("description"));
+        pf.setType((String) dbObject.get("type"));
+        pf.setValue((String) dbObject.get("value"));
         if (dbObject.containsField("fixedValues")) {
             BasicDBList dbList = (BasicDBList) dbObject.get("fixedValues");
             if (dbList != null) {

--- a/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
+++ b/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
@@ -87,7 +87,7 @@ public final class FF4jDroolsService implements Serializable {
      *      singleton already created.
      */
     public static synchronized boolean isInitialized() {
-        return (_instance != null && _instance.ksession != null);
+        return _instance != null && _instance.ksession != null;
     }
     
     /**

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
@@ -101,15 +101,15 @@ public class FF4jAuthorizationFilter implements ContainerRequestFilter, FF4jWebC
     }
     
     private boolean isPermitAll() {
-        return (info.getResourceMethod().getAnnotation(PermitAll.class) != null);
+        return info.getResourceMethod().getAnnotation(PermitAll.class) != null;
     }
     
     private boolean isDenyAll() {
-        return (info.getResourceMethod().getAnnotation(DenyAll.class) != null);
+        return info.getResourceMethod().getAnnotation(DenyAll.class) != null;
     }
     
     private boolean isRolesAllowed() {
-        return (info.getResourceMethod().getAnnotation(RolesAllowed.class) != null);
+        return info.getResourceMethod().getAnnotation(RolesAllowed.class) != null;
     }
     
     private Set < String > getRoles() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
Please let me know if you have any questions.
George Kankava