### PR TITLE
squid:S2095 - Resources should be closed

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/InMemoryEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/InMemoryEventRepository.java
@@ -130,6 +130,7 @@ public class InMemoryEventRepository extends AbstractEventRepository {
                     break;
                     case DISABLE_FEATURE:
                         nbDisable++;
+                    break;
                     default:
                     break;
                 }

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
@@ -263,6 +263,7 @@ public class JdbcEventRepository extends AbstractEventRepository implements Jdbc
                     break;
                     case DISABLE_FEATURE:
                         nbDisable++;
+                    break;
                     default:
                     break;
                 }

--- a/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
+++ b/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
@@ -187,8 +187,9 @@ public final class FF4jDroolsService implements Serializable {
      *      file content as string
      */
     private final static String loadResourceAsString(final String resourceName) {
+        InputStream rin = null;
         try {
-            InputStream rin = ClassLoader.getSystemResourceAsStream(resourceName);
+            rin = ClassLoader.getSystemResourceAsStream(resourceName);
             StringBuffer out = new StringBuffer();
             byte[] b = new byte[4096];
             int n = 0;
@@ -199,6 +200,14 @@ public final class FF4jDroolsService implements Serializable {
             return out.toString();
         } catch (IOException ioe) {
             throw new IllegalArgumentException("Cannot read resource " + resourceName, ioe);
+        } finally {
+            if(rin != null) {
+                try {
+                    rin.close();
+                } catch (IOException e) {
+                    LOGGER.error("Exception while closing resource", e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2095 - Resources should be closed.
squid:S128 - Switch cases should end with an unconditional "break" statement.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2095
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS128
Please let me know if you have any questions.
George Kankava