### PR TITLE
multiple code improvements: squid:S2696, squid:S2275, squid:S2178, squid:S2226

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
@@ -80,7 +80,7 @@ public class FeatureAdvisor implements MethodInterceptor, BeanPostProcessor, App
 
                 // Required parameters
                 if (!assertRequiredParams(ff)) {
-                    String msg = String.format("alterBeanName or alterClazz is required for {}", method.getDeclaringClass());
+                    String msg = String.format("alterBeanName or alterClazz is required for {%s}", method.getDeclaringClass());
                     throw new IllegalArgumentException(msg);
                 }
                 if (shouldCallAlterBeanMethod(pMInvoc, ff.alterBean(), targetLogger)) {

--- a/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
+++ b/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
@@ -475,7 +475,7 @@ public final class XmlParser {
      * @throws ParserConfigurationException
      *             error during initialization
      */
-    public DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
+    public static DocumentBuilder getDocumentBuilder() throws ParserConfigurationException {
         if (builder == null) {
             builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             builder.setErrorHandler(new XmlParserErrorHandler());

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -498,7 +498,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
      */
     public void createCustomProperties(String uid, Collection <Property<?> > props) {
         Util.assertNotNull(uid);
-        if (props == null | props.isEmpty()) return;
+        if (props == null || props.isEmpty()) return;
        
         Connection sqlConn = null;
         PreparedStatement ps = null;

--- a/ff4j-web/src/main/java/org/ff4j/web/FF4jInitServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/FF4jInitServlet.java
@@ -39,7 +39,7 @@ public class FF4jInitServlet extends HttpServlet implements ConsoleConstants {
     private static final long serialVersionUID = 8447941463286918975L;
     
     /** Logger for this class. */
-    public Logger logger = LoggerFactory.getLogger(getClass());
+    public static final Logger logger = LoggerFactory.getLogger(FF4jInitServlet.class);
 
     /** {@inheritDoc} */
     @Override

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
@@ -55,7 +55,7 @@ public class ConsoleServlet extends HttpServlet implements ConsoleConstants {
     private static final long serialVersionUID = -3982043895954284269L;
 
     /** Logger for this class. */
-    public Logger LOGGER = LoggerFactory.getLogger(getClass());
+    public static final Logger LOGGER = LoggerFactory.getLogger(ConsoleServlet.class);
 
     /** instance of ff4j. */
     private FF4j ff4j = null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2696 - Instance methods should not write to "static" fields.
squid:S2275 - Printf-style format strings should not lead to unexpected behavior at runtime.
squid:S2178 - Short-circuit logic should be used in boolean contexts.
squid:S2226 - Servlets should not have mutable instance fields.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2696
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2275
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2178
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2226
Please let me know if you have any questions.
George Kankava
