### PR TITLE
squid:S2185 - Silly math should not be performed

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -545,13 +545,13 @@ public class FF4j {
         StringBuilder sb = new StringBuilder("{");
         // Render Uptime as String "X day(s) X hours(s) X minute(s) X seconds"
         long uptime = System.currentTimeMillis() - startTime;
-        long daynumber = (long) Math.floor(uptime / (1000 * 3600 * 24));
+        long daynumber = (long) uptime / (1000 * 3600 * 24);
         uptime = uptime - (daynumber * 1000 * 3600 * 24);
-        long hourNumber = (long) Math.floor(uptime / (1000 * 3600));
+        long hourNumber = (long) uptime / (1000 * 3600);
         uptime = uptime - (hourNumber * 1000 * 3600);
-        long minutenumber = (long) Math.floor(uptime / (1000 * 60));
+        long minutenumber = (long) uptime / (1000 * 60);
         uptime = uptime - (minutenumber * 1000 * 60);
-        long secondnumber = (long) Math.floor(uptime / 1000);
+        long secondnumber = (long) uptime / 1000;
         sb.append("\"uptime\":\"");
         sb.append(daynumber + " day(s) ");
         sb.append(hourNumber + " hours(s) ");

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/domain/FF4jStatusApiBean.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/domain/FF4jStatusApiBean.java
@@ -87,13 +87,13 @@ public final class FF4jStatusApiBean {
     public FF4jStatusApiBean(FF4j ff4j) {
         // UpTime
         long up = System.currentTimeMillis() - ff4j.getStartTime();
-        long daynumber = (long) Math.floor(up / (1000 * 3600 * 24));
+        long daynumber = (long) up / (1000 * 3600 * 24);
         up = up - (daynumber * 1000 * 3600 * 24);
-        long hourNumber = (long) Math.floor(up / (1000 * 3600));
+        long hourNumber = (long) up / (1000 * 3600);
         up = up - (hourNumber * 1000 * 3600);
-        long minutenumber = (long) Math.floor(up / (1000 * 60));
+        long minutenumber = (long) up / (1000 * 60);
         up = up - (minutenumber * 1000 * 60);
-        long secondnumber = (long) Math.floor(up / 1000);
+        long secondnumber = (long) up / 1000;
         uptime =  daynumber + " day(s) ";
         uptime += hourNumber + " hours(s) ";
         uptime += minutenumber + " minute(s) ";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2185 - Silly math should not be performed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2185
Please let me know if you have any questions.
George Kankava