### PR TITLE
Multiple code improvements: squid:S2325, squid:EmptyStatementUsageCheck

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
@@ -311,7 +311,7 @@ public class FeatureAdvisor implements MethodInterceptor, BeanPostProcessor, App
                 + pMInvoc.getMethod().getDeclaringClass());
     }
 
-    private Object callAlterClazzMethod(final MethodInvocation pMInvoc, Object targetBean, Logger targetLogger) {
+    private static Object callAlterClazzMethod(final MethodInvocation pMInvoc, Object targetBean, Logger targetLogger) {
         Method method = pMInvoc.getMethod();
         String declaringClass = method.getDeclaringClass().getName();
         targetLogger.debug("FeatureFlipping on method:{} class:{}", method.getName(), declaringClass);

--- a/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
+++ b/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
@@ -443,7 +443,7 @@ public final class XmlParser {
      *            current working tag
      * @return description of the feature
      */
-    private String parseDescription(NamedNodeMap nnm) {
+    private static String parseDescription(NamedNodeMap nnm) {
         String desc = null;
         if (nnm.getNamedItem(FEATURE_ATT_DESC) != null) {
             desc = nnm.getNamedItem(FEATURE_ATT_DESC).getNodeValue();
@@ -458,7 +458,7 @@ public final class XmlParser {
      *            current TAG
      * @return list of authorizations.
      */
-    private Set<String> parseListAuthorizations(Element securityTag) {
+    private static Set<String> parseListAuthorizations(Element securityTag) {
         Set<String> authorizations = new TreeSet<String>();
         NodeList lisOfAuth = securityTag.getElementsByTagName(SECURITY_ROLE_TAG);
         for (int k = 0; k < lisOfAuth.getLength(); k++) {

--- a/ff4j-core/src/main/java/org/ff4j/property/PropertyLogLevel.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/PropertyLogLevel.java
@@ -36,7 +36,7 @@ public class PropertyLogLevel extends Property<LogLevel> {
     private static final long serialVersionUID = 1792311055570779010L;
 
     /** Expected Log Levels. */
-    public static enum LogLevel {TRACE, DEBUG, INFO, WARN, ERROR, FATAL};
+    public static enum LogLevel {TRACE, DEBUG, INFO, WARN, ERROR, FATAL}
     
     /**
      * Constructor by string expression.

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -51,7 +51,7 @@ import org.ff4j.utils.JdbcUtils;
 import org.ff4j.utils.MappingUtil;
 import org.ff4j.utils.Util;
 
-;/**
+/**
  * Implementation of {@link FeatureStore} to work with RDBMS through JDBC.
  * 
  * @author Cedrick Lunven (@clunven)

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
@@ -126,7 +126,7 @@ public class FF4jAuthorizationFilter implements ContainerRequestFilter, FF4jWebC
         
     }
     
-    private void forbidden() {
+    private static void forbidden() {
         throw new WebApplicationException(Response.status(Status.FORBIDDEN) //
                 .entity("Cannot reach ressource, forbidden check @RoleAllowed, @DenyAll") //
                 .type(MediaType.TEXT_HTML_TYPE).build());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2325 - "private" methods that don't access instance data should be "static"
squid:EmptyStatementUsageCheck - Empty statements should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AEmptyStatementUsageCheck
Please let me know if you have any questions.
George Kankava