### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jNameSpaceHandler.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jNameSpaceHandler.java
@@ -35,17 +35,17 @@ public class FF4jNameSpaceHandler extends NamespaceHandlerSupport implements FF4
     /** Logger statique pour la classe. **/
     private static Log logger = LogFactory.getLog(FF4jNameSpaceHandler.class);
 
-    /** {@inheritDoc} */
-    public void init() {
-        logger.debug("Parsing FF4J Spring Namespace Elements");
-    }
-
     /**
      * Default Constructor to register Parser in the handler.
      */
     public FF4jNameSpaceHandler() {
         registerBeanDefinitionParser(TAG_FF4J, new FF4jBeanDefinitionParser());
         registerBeanDefinitionParser(TAG_PLACEHOLDER, new FF4JPlaceHolderBeanDefinitionParser());
+    }
+
+    /** {@inheritDoc} */
+    public void init() {
+        logger.debug("Parsing FF4J Spring Namespace Elements");
     }
 
 }

--- a/ff4j-core/src/main/java/org/ff4j/audit/graph/PieChart.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/graph/PieChart.java
@@ -39,7 +39,17 @@ public class PieChart implements Serializable {
     
     /** sector for the graph. */
     private List < PieSector > sectors = new ArrayList<PieSector>();
-    
+
+    /**
+     * Constructor with title.
+     *
+     * @param t
+     *      target title.
+     */
+    public PieChart(String t) {
+        this.title = t;
+    }
+
     /** {@inheritDoc} */
     public String toJson() {
         StringBuilder sb = new StringBuilder("{");
@@ -63,16 +73,6 @@ public class PieChart implements Serializable {
     @Override
     public String toString() {
         return toJson();
-    }
-    
-    /**
-     * Constructor with title.
-     *
-     * @param t
-     *      target title.
-     */
-    public PieChart(String t) {
-        this.title = t;
     }
 
     /**

--- a/ff4j-core/src/main/java/org/ff4j/audit/graph/PieSector.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/graph/PieSector.java
@@ -53,17 +53,7 @@ public class PieSector implements Serializable {
         this.label = l;
         this.value = v;
     }
-    
-    /** {@inheritDoc} */
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{ \"label\" : \"" + getLabel() + "\", ");
-        sb.append(" \"hitcount\" : " + getValue() + ", ");
-        sb.append(" \"color\" : \"#" + getColor() + "\" }");
-        return sb.toString();
-    }
-    
+
     /**
      * Constructor.
      *
@@ -75,6 +65,16 @@ public class PieSector implements Serializable {
     public PieSector(String l, double v, String color) {
         this(l,v);
         this.color = color;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{ \"label\" : \"" + getLabel() + "\", ");
+        sb.append(" \"hitcount\" : " + getValue() + ", ");
+        sb.append(" \"color\" : \"#" + getColor() + "\" }");
+        return sb.toString();
     }
 
     /**

--- a/ff4j-core/src/main/java/org/ff4j/property/util/PropertyFactory.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/util/PropertyFactory.java
@@ -53,12 +53,12 @@ import org.ff4j.utils.Util;
  */
 public class PropertyFactory {
 
+    private static Map < Class<?> , Class<?> > validPropertyPrimitives = new HashMap<Class<?>, Class<?> >();
+
     /**
      * Hide constructor as util class.
      */
     public PropertyFactory() {}
-    
-    private static Map < Class<?> , Class<?> > validPropertyPrimitives = new HashMap<Class<?>, Class<?> >();
     
     /**
      * Initialized Primitive to work with Properties.

--- a/ff4j-core/src/main/java/org/ff4j/utils/MappingUtil.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/MappingUtil.java
@@ -51,6 +51,7 @@ public class MappingUtil {
 
     /** Separator to propose parameters. */
     private static final String SEPARATOR = "&";
+    private static Map < String, String > PROPERTY_TYPES;
 
     /**
      * Hiding default constructor for utility class.
@@ -58,7 +59,6 @@ public class MappingUtil {
     private MappingUtil() {}
     
     /** Substitution in XML or any store. */
-    private static Map < String, String > PROPERTY_TYPES;
     
     /**
      * Initialisation of substitution types

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/FF4JApiApplication.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/FF4JApiApplication.java
@@ -56,24 +56,6 @@ public abstract class FF4JApiApplication extends PackagesResourceConfig {
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
     /**
-     * Child class must fullfil the configuration of the apicd
-     * 
-     * @return
-     */
-    protected abstract ApiConfig getApiConfig();
-
-    /**
-     * Injection of bean ff4j within this static class.
-     *
-     * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
-     */
-    public static class FF4jInjectableProvider extends SingletonTypeInjectableProvider<Context, FF4j> {
-        public FF4jInjectableProvider(FF4j ff4j) {
-            super(FF4j.class, ff4j);
-        }
-    }
-
-    /**
      * Constructor to defined resources.
      */
     public FF4JApiApplication() {
@@ -135,6 +117,24 @@ public abstract class FF4JApiApplication extends PackagesResourceConfig {
             
            getSingletons().add(io.swagger.jaxrs.listing.ApiListingResource.class);
            getSingletons().add(io.swagger.jaxrs.listing.SwaggerSerializers.class);
+        }
+    }
+
+    /**
+     * Child class must fullfil the configuration of the apicd
+     * 
+     * @return
+     */
+    protected abstract ApiConfig getApiConfig();
+
+    /**
+     * Injection of bean ff4j within this static class.
+     *
+     * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
+     */
+    public static class FF4jInjectableProvider extends SingletonTypeInjectableProvider<Context, FF4j> {
+        public FF4jInjectableProvider(FF4j ff4j) {
+            super(FF4j.class, ff4j);
         }
     }
 

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/FF4jApiApplicationJersey2x.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/FF4jApiApplicationJersey2x.java
@@ -50,7 +50,16 @@ public abstract class FF4jApiApplicationJersey2x extends ResourceConfig {
      * Configuration for this.
      */
     private ApiConfig apiConfig;
-    
+
+    /**
+     * Initialisation of Jersey2 application.
+     *
+     * @param serviceLocator
+     */
+    public FF4jApiApplicationJersey2x() {
+        init();
+    }
+
     protected abstract ApiConfig getWebApiConfiguration();
    
     /**
@@ -65,15 +74,6 @@ public abstract class FF4jApiApplicationJersey2x extends ResourceConfig {
             bind(getWebApiConfiguration().getFF4j()).to(FF4j.class);
             log.info("FF4J is now bound to Jersey Context.");
         }
-    }
-    
-    /**
-     * Initialisation of Jersey2 application.
-     *
-     * @param serviceLocator
-     */
-    public FF4jApiApplicationJersey2x() {
-        init();
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava