### PR TITLE
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
@@ -46,7 +46,7 @@ public class EventPublisher {
     public static final int DEFAULT_POOL_SIZE = 4;
     
     /** 2s to save the event other wize skip. */
-    public static long timeout = 2000L;
+    public static final long timeout = 2000L;
     
     /** Executor for item writer. */
     private ExecutorService executor;

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
 
     /** Simulate Interrupted. */
-    public static boolean mock = false;
+    private static boolean mock = false;
     
     /** {@inheritDoc} */
     @Override
@@ -57,6 +57,14 @@ public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
     public void waitInSeconds(int nbSecond) throws InterruptedException {
         if (mock) throw new InterruptedException();
         Thread.sleep(1000 * nbSecond);
+    }
+
+    public static boolean isMock() {
+        return mock;
+    }
+
+    public static void setMock(boolean mock) {
+        EventRejectedExecutionHandler.mock = mock;
     }
 
 }

--- a/ff4j-core/src/main/java/org/ff4j/property/multi/AbstractPropertyMultiValued.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/multi/AbstractPropertyMultiValued.java
@@ -43,7 +43,7 @@ public abstract class AbstractPropertyMultiValued < T, C extends Collection< T>>
     private static final long serialVersionUID = 1L;
     
     /** required if should be splip. */
-    public String listDelimiter = ",";
+    private String listDelimiter = ",";
     
     /**
      * Default constructor.

--- a/ff4j-core/src/main/java/org/ff4j/strategy/el/ExpressionFlipStrategy.java
+++ b/ff4j-core/src/main/java/org/ff4j/strategy/el/ExpressionFlipStrategy.java
@@ -34,7 +34,7 @@ public class ExpressionFlipStrategy extends AbstractFlipStrategy implements Seri
     private static final long serialVersionUID = 4739173170455721752L;
 
     /** Expected parameter. */
-    public static String PARAM_EXPRESSION = "expression";
+    public static final String PARAM_EXPRESSION = "expression";
 
     /** Cached init value. */
     private static Map<String, String> mapOfValue = new HashMap<String, String>();

--- a/ff4j-core/src/test/java/org/ff4j/test/utils/ExceptionsTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/utils/ExceptionsTest.java
@@ -89,9 +89,9 @@ public class ExceptionsTest {
     
     @Test
     public void testExceptionHandlerInterrupted() throws InterruptedException {
-        EventRejectedExecutionHandler.mock = true;
+        EventRejectedExecutionHandler.setMock(true);
         EventRejectedExecutionHandler ereh = new EventRejectedExecutionHandler();
         ereh.rejectedExecution(new Thread(), null);
-        EventRejectedExecutionHandler.mock = false;
+        EventRejectedExecutionHandler.setMock(false);
     }
 }

--- a/ff4j-store-redis/src/main/java/org/ff4j/cache/FeatureCacheProviderRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/cache/FeatureCacheProviderRedis.java
@@ -38,10 +38,10 @@ import redis.clients.jedis.Jedis;
 public class FeatureCacheProviderRedis implements FF4JCacheManager {
     
     /** prefix of keys. */
-    public static String KEY_FEATURE = "FF4J_FEATURE_";
+    public static final String KEY_FEATURE = "FF4J_FEATURE_";
     
     /** prefix of keys. */
-    public static String KEY_PROPERTY = "FF4J_PROPERTY_";
+    public static final String KEY_PROPERTY = "FF4J_PROPERTY_";
     
     /** default ttl. */
     private static int DEFAULT_TTL = 900000000;

--- a/ff4j-store-redis/src/main/java/org/ff4j/store/FeatureStoreRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/store/FeatureStoreRedis.java
@@ -44,7 +44,7 @@ import redis.clients.jedis.Jedis;
 public class FeatureStoreRedis extends AbstractFeatureStore {
     
     /** prefix of keys. */
-    public static String KEY_FEATURE = "FF4J_FEATURE_";
+    public static final String KEY_FEATURE = "FF4J_FEATURE_";
     
     /** default ttl. */
     private static int DEFAULT_TTL = 900000000;

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleOperations.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleOperations.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 public class ConsoleOperations implements ConsoleConstants {
     
     /** Logger for this class. */
-    public static Logger LOGGER = LoggerFactory.getLogger(ConsoleOperations.class);
+    private static Logger LOGGER = LoggerFactory.getLogger(ConsoleOperations.class);
     
     /**
      * User action to create a new Feature.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava
