### PR TITLE
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/graph/BarChart.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/graph/BarChart.java
@@ -71,11 +71,11 @@ public class BarChart extends AbstractGraphFF4j {
         sb.append(" \"title\" : \"" +  getTitle() + "\", ");
         sb.append(" \"series\" : [");
         boolean first = true;
-        for(String bs : series.keySet()) {
+        for(Map.Entry<String, BarSeries> bs : series.entrySet()) {
             if (!first) {
                 sb.append(",");
             }
-            sb.append(series.get(bs).toString());
+            sb.append(bs.getValue());
             first= false;
         }
         sb.append("],");

--- a/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
+++ b/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
@@ -584,13 +584,13 @@ public final class XmlParser {
             }
         }
             
-        for (String groupName : featuresPerGroup.keySet()) {
+        for (Map.Entry<String,List<Feature>> groupName : featuresPerGroup.entrySet()) {
             /// Building featureGroup
-            if (null != groupName && !groupName.isEmpty()) {
-                sb.append(" <" + FEATUREGROUP_TAG + " " + FEATUREGROUP_ATTNAME + "=\"" + groupName + "\" >\n\n");
+            if (null != groupName.getKey() && !groupName.getKey().isEmpty()) {
+                sb.append(" <" + FEATUREGROUP_TAG + " " + FEATUREGROUP_ATTNAME + "=\"" + groupName.getKey() + "\" >\n\n");
             }
             // Loop on feature
-            for (Feature feat : featuresPerGroup.get(groupName)) {
+            for (Feature feat : groupName.getValue()) {
                 sb.append(MessageFormat.format(XML_FEATURE, feat.getUid(), feat.getDescription(), feat.isEnable()));
                 // <security>
                 if (null != feat.getPermissions() && !feat.getPermissions().isEmpty()) {
@@ -626,7 +626,7 @@ public final class XmlParser {
                 sb.append(END_FEATURE);
             }
             
-            if (null != groupName && !groupName.isEmpty()) {
+            if (null != groupName.getKey() && !groupName.getKey().isEmpty()) {
                 sb.append(" </" + FEATUREGROUP_TAG + ">\n\n");
             }
         }

--- a/ff4j-core/src/main/java/org/ff4j/property/store/AbstractPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/AbstractPropertyStore.java
@@ -58,11 +58,11 @@ public abstract class AbstractPropertyStore implements PropertyStore {
         Map<String, Property<?>> properties = conf.getProperties();
 
         // Override existing configuration within database
-        for (String featureName : properties.keySet()) {
-            if (existProperty(featureName)) {
-                deleteProperty(featureName);
+        for (Map.Entry<String,Property<?>> featureName : properties.entrySet()) {
+            if (existProperty(featureName.getKey())) {
+                deleteProperty(featureName.getKey());
             }
-            createProperty(properties.get(featureName));
+            createProperty(featureName.getValue());
         }
         return properties;
     }

--- a/ff4j-core/src/main/java/org/ff4j/store/AbstractFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/AbstractFeatureStore.java
@@ -61,11 +61,11 @@ public abstract class AbstractFeatureStore implements FeatureStore {
         Map < String, Feature > features = conf.getFeatures();
 
         // Override existing configuration within database
-        for (String featureName : features.keySet()) {
-            if (exist(featureName)) {
-                delete(featureName);
+        for (Map.Entry<String,Feature> featureName : features.entrySet()) {
+            if (exist(featureName.getKey())) {
+                delete(featureName.getKey());
             }
-            create(features.get(featureName));
+            create(featureName.getValue());
         }
         return features;
     }

--- a/ff4j-core/src/main/java/org/ff4j/utils/JsonUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/JsonUtils.java
@@ -124,9 +124,9 @@ public class JsonUtils {
         StringBuilder json = new StringBuilder("{");
         if (null != customProperties && !customProperties.isEmpty()) {
             boolean first = true;
-            for (String key : customProperties.keySet()) {
+            for (Map.Entry<String, ? extends Property<?>> key : customProperties.entrySet()) {
                 json.append(first ? "" : ",");
-                json.append("\"" + key + "\":" + customProperties.get(key).toJson());
+                json.append("\"" + key.getKey() + "\":" + key.getValue().toJson());
                 first = false;
             }
         }

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/store/FeatureStoreEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/store/FeatureStoreEhCache.java
@@ -186,9 +186,9 @@ public class FeatureStoreEhCache extends AbstractFeatureStore implements FF4JEhC
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
         Map < String, Feature > group = new HashMap<String, Feature>();
-        for (String uid : features.keySet()) {
-            if (groupName.equals(features.get(uid).getGroup())) {
-                group.put(uid, features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            if (groupName.equals(uid.getValue().getGroup())) {
+                group.put(uid.getKey(), uid.getValue());
             }
         }
         if (group.isEmpty()) {
@@ -203,9 +203,9 @@ public class FeatureStoreEhCache extends AbstractFeatureStore implements FF4JEhC
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
         Map < String, Feature > group = new HashMap<String, Feature>();
-        for (String uid : features.keySet()) {
-            if (groupName.equals(features.get(uid).getGroup())) {
-                group.put(uid, features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            if (groupName.equals(uid.getValue().getGroup())) {
+                group.put(uid.getKey(), uid.getValue());
             }
         }
         return !group.isEmpty();
@@ -215,9 +215,9 @@ public class FeatureStoreEhCache extends AbstractFeatureStore implements FF4JEhC
     @Override
     public void enableGroup(String groupName) {
         Map < String, Feature > features = readGroup(groupName);
-        for (String uid : features.keySet()) {
-            features.get(uid).enable();
-            update(features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            uid.getValue().enable();
+            update(uid.getValue());
         }
     }
 
@@ -225,9 +225,9 @@ public class FeatureStoreEhCache extends AbstractFeatureStore implements FF4JEhC
     @Override
     public void disableGroup(String groupName) {
         Map < String, Feature > features = readGroup(groupName);
-        for (String uid : features.keySet()) {
-            features.get(uid).disable();
-            update(features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            uid.getValue().disable();
+            update(uid.getValue());
         }
     }
 
@@ -261,8 +261,8 @@ public class FeatureStoreEhCache extends AbstractFeatureStore implements FF4JEhC
     public Set<String> readAllGroups() {
         Map < String, Feature > features = readAll();
         Set < String > groups = new HashSet<String>();
-        for (String uid : features.keySet()) {
-            groups.add(features.get(uid).getGroup());
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            groups.add(uid.getValue().getGroup());
         }
         groups.remove(null);
         return groups;

--- a/ff4j-store-jcache/src/main/java/org/ff4j/store/FeatureStoreJCache.java
+++ b/ff4j-store-jcache/src/main/java/org/ff4j/store/FeatureStoreJCache.java
@@ -167,9 +167,9 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
         Map < String, Feature > group = new HashMap<>();
-        for (String uid : features.keySet()) {
-            if (groupName.equals(features.get(uid).getGroup())) {
-                group.put(uid, features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            if (groupName.equals(uid.getValue().getGroup())) {
+                group.put(uid.getKey(), uid.getValue());
             }
         }
         if (group.isEmpty()) {
@@ -184,9 +184,9 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
         Map < String, Feature > group = new HashMap<>();
-        for (String uid : features.keySet()) {
-            if (groupName.equals(features.get(uid).getGroup())) {
-                group.put(uid, features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            if (groupName.equals(uid.getValue().getGroup())) {
+                group.put(uid.getKey(), uid.getValue());
             }
         }
         return !group.isEmpty();
@@ -196,9 +196,9 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     @Override
     public void enableGroup(String groupName) {
         Map < String, Feature > features = readGroup(groupName);
-        for (String uid : features.keySet()) {
-            features.get(uid).enable();
-            update(features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            uid.getValue().enable();
+            update(uid.getValue());
         }
     }
 
@@ -206,9 +206,9 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     @Override
     public void disableGroup(String groupName) {
         Map < String, Feature > features = readGroup(groupName);
-        for (String uid : features.keySet()) {
-            features.get(uid).disable();
-            update(features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            uid.getValue().disable();
+            update(uid.getValue());
         }
     }
 
@@ -242,8 +242,8 @@ public class FeatureStoreJCache extends AbstractFeatureStore {
     public Set<String> readAllGroups() {
         Map < String, Feature > features = readAll();
         Set < String > groups = new HashSet<>();
-        for (String uid : features.keySet()) {
-            groups.add(features.get(uid).getGroup());
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            groups.add(uid.getValue().getGroup());
         }
         groups.remove(null);
         return groups;

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
@@ -168,8 +168,8 @@ public final class FeatureDocumentMapper implements FeatureStoreMongoConstants {
         if (dbObject.containsKey(CUSTOMPROPERTIES)) {
             String properties = (String) dbObject.get(CUSTOMPROPERTIES);
             Map < String, DBObject > values = (Map<String, DBObject>) JSON.parse(properties);
-            for (String key : values.keySet()) {
-                mapOfCustomProperties.put(key, mapProperty(values.get(key)));
+            for (Map.Entry<String,DBObject> entry : values.entrySet()) {
+                mapOfCustomProperties.put(entry.getKey(), mapProperty(entry.getValue()));
             }
         }
         return mapOfCustomProperties;

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectMapper.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectMapper.java
@@ -175,8 +175,8 @@ public final class FeatureDBObjectMapper implements FeatureStoreMongoConstants {
         if (dbObject.containsField(CUSTOMPROPERTIES)) {
             String properties = (String) dbObject.get(CUSTOMPROPERTIES);
             Map < String, BasicDBObject > values = (Map<String, BasicDBObject>) JSON.parse(properties);
-            for (String key : values.keySet()) {
-                mapOfCustomProperties.put(key, mapProperty(values.get(key)));
+            for (Map.Entry<String,BasicDBObject> entry : values.entrySet()) {
+                mapOfCustomProperties.put(entry.getKey(), mapProperty(entry.getValue()));
             }
         }
         return mapOfCustomProperties;

--- a/ff4j-store-redis/src/main/java/org/ff4j/store/FeatureStoreRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/store/FeatureStoreRedis.java
@@ -211,9 +211,9 @@ public class FeatureStoreRedis extends AbstractFeatureStore {
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
         Map < String, Feature > group = new HashMap<String, Feature>();
-        for (String uid : features.keySet()) {
-            if (groupName.equals(features.get(uid).getGroup())) {
-                group.put(uid, features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            if (groupName.equals(uid.getValue().getGroup())) {
+                group.put(uid.getKey(), uid.getValue());
             }
         }
         if (group.isEmpty()) {
@@ -228,9 +228,9 @@ public class FeatureStoreRedis extends AbstractFeatureStore {
         Util.assertParamNotNull(groupName, "groupName");
         Map < String, Feature > features = readAll();
         Map < String, Feature > group = new HashMap<String, Feature>();
-        for (String uid : features.keySet()) {
-            if (groupName.equals(features.get(uid).getGroup())) {
-                group.put(uid, features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            if (groupName.equals(uid.getValue().getGroup())) {
+                group.put(uid.getKey(), uid.getValue());
             }
         }
         return !group.isEmpty();
@@ -240,9 +240,9 @@ public class FeatureStoreRedis extends AbstractFeatureStore {
     @Override
     public void enableGroup(String groupName) {
         Map < String, Feature > features = readGroup(groupName);
-        for (String uid : features.keySet()) {
-            features.get(uid).enable();
-            update(features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            uid.getValue().enable();
+            update(uid.getValue());
         }
     }
 
@@ -250,9 +250,9 @@ public class FeatureStoreRedis extends AbstractFeatureStore {
     @Override
     public void disableGroup(String groupName) {
         Map < String, Feature > features = readGroup(groupName);
-        for (String uid : features.keySet()) {
-            features.get(uid).disable();
-            update(features.get(uid));
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            uid.getValue().disable();
+            update(uid.getValue());
         }
     }
 
@@ -286,8 +286,8 @@ public class FeatureStoreRedis extends AbstractFeatureStore {
     public Set<String> readAllGroups() {
         Map < String, Feature > features = readAll();
         Set < String > groups = new HashSet<String>();
-        for (String uid : features.keySet()) {
-            groups.add(features.get(uid).getGroup());
+        for (Map.Entry<String,Feature> uid : features.entrySet()) {
+            groups.add(uid.getValue().getGroup());
         }
         groups.remove(null);
         return groups;

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/FeatureStoreSpringJdbc.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/FeatureStoreSpringJdbc.java
@@ -352,9 +352,9 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
         RoleRowMapper rrm = new RoleRowMapper();
         getJdbcTemplate().query(SQL_GET_ALLROLES, rrm);
         Map<String, Set<String>> roles = rrm.getRoles();
-        for (String featId : roles.keySet()) {
-            if (mapFP.containsKey(featId)) {
-                mapFP.get(featId).getPermissions().addAll(roles.get(featId));
+        for (Map.Entry<String,Set<String>> featId : roles.entrySet()) {
+            if (mapFP.containsKey(featId.getKey())) {
+                mapFP.get(featId.getKey()).getPermissions().addAll(featId.getValue());
             }
         }
         return mapFP;

--- a/ff4j-test/src/main/java/org/ff4j/test/propertystore/PropertyStoreTestSupport.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/propertystore/PropertyStoreTestSupport.java
@@ -360,8 +360,8 @@ public abstract class PropertyStoreTestSupport {
         Assert.assertTrue(testedStore.readAllProperties().isEmpty());
         
         /// Reinit
-        for (String pName : before.keySet()) {
-            testedStore.createProperty(before.get(pName));
+        for (Map.Entry<String,Property<?>> pName : before.entrySet()) {
+            testedStore.createProperty(pName.getValue());
         }
     }
     

--- a/ff4j-test/src/main/java/org/ff4j/test/store/FeatureStoreTestSupport.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/store/FeatureStoreTestSupport.java
@@ -1061,8 +1061,8 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
         // Then
         Assert.assertTrue(testedStore.readAll().isEmpty());
         /// Reinit
-        for (String pName : before.keySet()) {
-            testedStore.create(before.get(pName));
+        for (Map.Entry<String,Feature> pName : before.entrySet()) {
+            testedStore.create(pName.getValue());
         }
     }
     

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleRenderer.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleRenderer.java
@@ -221,8 +221,8 @@ public final class ConsoleRenderer implements ConsoleConstants {
     static final String renderPropertiesRows(FF4j ff4j, HttpServletRequest req) {
         StringBuilder sb = new StringBuilder();
         final Map < String, Property<?>> mapOfProperties = ff4j.getProperties();
-        for(String uid : mapOfProperties.keySet()) {
-            Property<?> currentProperty = mapOfProperties.get(uid);
+        for(Map.Entry<String,Property<?>> uid : mapOfProperties.entrySet()) {
+            Property<?> currentProperty = uid.getValue();
             sb.append("<tr>" + END_OF_LINE);
             
             // Column with uid and description as tooltip
@@ -291,8 +291,8 @@ public final class ConsoleRenderer implements ConsoleConstants {
     static final String renderFeatureRows(FF4j ff4j, HttpServletRequest req) {
         StringBuilder sb = new StringBuilder();
         final Map < String, Feature> mapOfFeatures = ff4j.getFeatures();
-        for(String uid : mapOfFeatures.keySet()) {
-            Feature currentFeature = mapOfFeatures.get(uid);
+        for(Map.Entry<String,Feature> uid : mapOfFeatures.entrySet()) {
+            Feature currentFeature = uid.getValue();
             sb.append("<tr>" + END_OF_LINE);
             
             // Column with uid and description as tooltip
@@ -380,7 +380,7 @@ public final class ConsoleRenderer implements ConsoleConstants {
             sb.append("<a href=\"");
             sb.append(req.getContextPath());
             sb.append(req.getServletPath());
-            sb.append("?op=" + OP_RMV_FEATURE + "&" + FEATID + "=" + uid);
+            sb.append("?op=" + OP_RMV_FEATURE + "&" + FEATID + "=" + uid.getKey());
             sb.append("\" style=\"width:6px;\" class=\"btn\">");
             sb.append("<i class=\"icon-trash\" style=\"margin-left:-5px;\"></i>");
             sb.append("</a>");

--- a/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagDisable.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagDisable.java
@@ -50,8 +50,8 @@ public class FeatureTagDisable extends AbstractFeatureTag {
             executionContext.putString("LOCALE", pageContext.getRequest().getLocalName());
             @SuppressWarnings("unchecked")
             Map < String, String[]> parameters = pageContext.getRequest().getParameterMap();
-            for (String param : parameters.keySet()) {
-                String[] innerParams = parameters.get(param);
+            for (Map.Entry<String,String[]> param : parameters.entrySet()) {
+                String[] innerParams = param.getValue();
                 if (innerParams != null) {
                     StringBuilder sb = new StringBuilder();
                     for (String innerParam : innerParams) {
@@ -59,7 +59,7 @@ public class FeatureTagDisable extends AbstractFeatureTag {
                         sb.append(",");
                     }
                     String expression = sb.toString();
-                    executionContext.putString(param, expression.substring(0, expression.length() - 1));
+                    executionContext.putString(param.getKey(), expression.substring(0, expression.length() - 1));
                 }
             }
         }

--- a/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagEnable.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/taglib/FeatureTagEnable.java
@@ -52,8 +52,8 @@ public class FeatureTagEnable extends AbstractFeatureTag {
             executionContext.putString("LOCALE", pageContext.getRequest().getLocalName());
             @SuppressWarnings("unchecked")
             Map < String, String[]> parameters = pageContext.getRequest().getParameterMap();
-            for (String param : parameters.keySet()) {
-                String[] innerParams = parameters.get(param);
+            for (Map.Entry<String,String[]> param : parameters.entrySet()) {
+                String[] innerParams = param.getValue();
                 if (innerParams != null) {
                     StringBuilder sb = new StringBuilder();
                     for (String innerParam : innerParams) {
@@ -61,7 +61,7 @@ public class FeatureTagEnable extends AbstractFeatureTag {
                         sb.append(",");
                     }
                     String expression = sb.toString();
-                    executionContext.putString(param, expression.substring(0, expression.length() - 1));
+                    executionContext.putString(param.getKey(), expression.substring(0, expression.length() - 1));
                 }
             }
         }

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
@@ -57,8 +57,8 @@ public class FF4JSecurityContextAuthenticationManager extends AbstractAuthorizat
         Set < String > vars = new HashSet<String>();
         if (FF4jSecurityContextFilter.securityConfig != null) {
             Map < String, Set<String > > perms = FF4jSecurityContextFilter.securityConfig.getPermissions();
-            for (String var : perms.keySet()) {
-                perms.get(var).addAll(perms.get(var));
+            for (Map.Entry<String,Set<String>> var : perms.entrySet()) {
+                var.getValue().addAll(var.getValue());
             }
         }
         return vars;

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
@@ -56,8 +56,8 @@ public class FF4JSecurityContextAuthenticationManager extends AbstractAuthorizat
         Set < String > vars = new HashSet<>();
         if (FF4jAuthenticationFilter.apiConfig != null) {
             Map < String, Set<String > > perms = FF4jAuthenticationFilter.apiConfig.getPermissions();
-            for (String var : perms.keySet()) {
-                perms.get(var).addAll(perms.get(var));
+            for (Map.Entry<String,Set<String>> var : perms.entrySet()) {
+                perms.get(var.getKey()).addAll(var.getValue());
             }
         }
         return vars;

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureStoreResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureStoreResource.java
@@ -110,14 +110,14 @@ public class FeatureStoreResource extends AbstractResource {
         Map< String , GroupDescApiBean > groups = new HashMap<String, GroupDescApiBean>();
         if (features != null && !features.isEmpty()) {
             // Build groups from features
-            for (String featureName : features.keySet()) {
-                String groupName = features.get(featureName).getGroup();
+            for (Map.Entry<String,Feature> featureName : features.entrySet()) {
+                String groupName = featureName.getValue().getGroup();
                 // Add current group to list
                 if (groupName != null && !groupName.isEmpty()) {
                     if (!groups.containsKey(groupName)) {
                         groups.put(groupName, new GroupDescApiBean(groupName, new ArrayList<String>()));
                     }
-                    groups.get(groupName).getFeatures().add(featureName);
+                    groups.get(groupName).getFeatures().add(featureName.getKey());
                 }
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2864
Please let me know if you have any questions.
George Kankava