### PR TITLE
Multiple code improvements: squid:S1905, squid:S106

### DIFF
--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/domain/FF4jStatusApiBean.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/domain/FF4jStatusApiBean.java
@@ -87,13 +87,13 @@ public final class FF4jStatusApiBean {
     public FF4jStatusApiBean(FF4j ff4j) {
         // UpTime
         long up = System.currentTimeMillis() - ff4j.getStartTime();
-        long daynumber = (long) up / (1000 * 3600 * 24);
+        long daynumber = up / (1000 * 3600 * 24);
         up = up - (daynumber * 1000 * 3600 * 24);
-        long hourNumber = (long) up / (1000 * 3600);
+        long hourNumber = up / (1000 * 3600);
         up = up - (hourNumber * 1000 * 3600);
-        long minutenumber = (long) up / (1000 * 60);
+        long minutenumber = up / (1000 * 60);
         up = up - (minutenumber * 1000 * 60);
-        long secondnumber = (long) up / 1000;
+        long secondnumber = up / 1000;
         uptime =  daynumber + " day(s) ";
         uptime += hourNumber + " hours(s) ";
         uptime += minutenumber + " minute(s) ";

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/security/FF4jSecurityContext.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/security/FF4jSecurityContext.java
@@ -27,13 +27,18 @@ import java.util.Set;
 
 import javax.ws.rs.core.SecurityContext;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Default implementation of security context.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
 public class FF4jSecurityContext implements SecurityContext, Serializable {
-    
+
+    public static final Logger logger = LoggerFactory.getLogger(FF4jSecurityContext.class);
+
     /** Serial. */
     private static final long serialVersionUID = 9041009506390024931L;
 
@@ -70,7 +75,7 @@ public class FF4jSecurityContext implements SecurityContext, Serializable {
     /** {@inheritDoc} */
     @Override
     public Principal getUserPrincipal() {
-        System.out.println("PRINCP");
+        logger.info("PRINCP");
         return new Principal() {
             /** {@inheritDoc} */
             @Override
@@ -83,7 +88,7 @@ public class FF4jSecurityContext implements SecurityContext, Serializable {
     /** {@inheritDoc} */
     @Override
     public boolean isUserInRole(String role) {
-        System.out.println("TEST ROLE " + role + " against " + userRoles);
+        logger.info("TEST ROLE " + role + " against " + userRoles);
         return userRoles.contains(role);
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1905 - Redundant casts should not be used.
squid:S106 - Standard outputs should not be used directly to log anything.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
George Kankava
