### PR TITLE
Multiple code improvements: squid:ForLoopCounterChangedCheck, squid:S1197

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/FF4jPropertiesPlaceHolderConfigurer.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/FF4jPropertiesPlaceHolderConfigurer.java
@@ -68,7 +68,7 @@ public class FF4jPropertiesPlaceHolderConfigurer implements BeanFactoryPostProce
             BeanDefinitionVisitor visitor = new PropertiesPlaceHolderBeanDefinitionVisitor(ff4j);
 
             // 2) Inject property & features value
-            String beanNames[] = beanFactory.getBeanDefinitionNames();
+            String[] beanNames = beanFactory.getBeanDefinitionNames();
             for (int i = 0; i < beanNames.length; i++) {
                 if (beanNames[i].equals(beanName) && beanFactory.equals(beanFactory)) {
                     continue;

--- a/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/PropertiesPlaceHolderBeanDefinitionVisitor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/PropertiesPlaceHolderBeanDefinitionVisitor.java
@@ -93,7 +93,8 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
         StringBuffer buf = new StringBuffer(strVal);
         
         // @ff4jProperty{}
-        for (int startIndex = strVal.indexOf(PLACEHOLDER_PROPERTY_PREFIX); startIndex != -1;) {
+        int startIndex = strVal.indexOf(PLACEHOLDER_PROPERTY_PREFIX);
+        while (startIndex != -1) {
             int endIndex = buf.toString().indexOf(PLACEHOLDER_SUFFIX, startIndex + PLACEHOLDER_PROPERTY_PREFIX.length());
             if (endIndex != -1) {
                 String placeholder = buf.substring(startIndex + PLACEHOLDER_PROPERTY_PREFIX.length(), endIndex);
@@ -122,7 +123,8 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
         }
         
         // @ff4jFeature{}
-        for (int startIndex = strVal.indexOf(PLACEHOLDER_FEATURE_PREFIX); startIndex != -1;) {
+        startIndex = strVal.indexOf(PLACEHOLDER_FEATURE_PREFIX);
+        while (startIndex != -1) {
             int endIndex = buf.toString().indexOf(PLACEHOLDER_SUFFIX, startIndex + PLACEHOLDER_FEATURE_PREFIX.length());
             if (endIndex != -1) {
                 String placeholder = buf.substring(startIndex + PLACEHOLDER_FEATURE_PREFIX.length(), endIndex);


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rules
squid:ForLoopCounterChangedCheck - "for" loop stop conditions should be invariant.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AForLoopCounterChangedCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1197
Please let me know if you have any questions.
George Kankava