### PR TITLE
squid:S2130 - Parsing should be used to convert "Strings" to primitives

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
+++ b/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
@@ -287,7 +287,7 @@ public final class XmlParser {
             throw new IllegalArgumentException("Error syntax in configuration file : "
                     + "'enable' is required for each feature (check " + uid + ")");
         }
-        boolean enable = Boolean.valueOf(nnm.getNamedItem(FEATURE_ATT_ENABLE).getNodeValue());
+        boolean enable = Boolean.parseBoolean(nnm.getNamedItem(FEATURE_ATT_ENABLE).getNodeValue());
 
         // Create Feature with description
         Feature f = new Feature(uid, enable, parseDescription(nnm));

--- a/ff4j-core/src/main/java/org/ff4j/property/Property.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/Property.java
@@ -180,7 +180,7 @@ public abstract class Property < T > implements Serializable {
      *      int value
      */
     public int asInt() {
-        return new Integer(asString()).intValue();
+        return Integer.parseInt(asString());
     }
 
     /**
@@ -190,7 +190,7 @@ public abstract class Property < T > implements Serializable {
      *      int value
      */
     public double asDouble() {
-        return new Double(asString()).doubleValue();
+        return Double.parseDouble(asString());
     }
     
     /**
@@ -200,7 +200,7 @@ public abstract class Property < T > implements Serializable {
      *      boolea value
      */
     public boolean asBoolean() {
-        return new Boolean(asString()).booleanValue();
+        return Boolean.parseBoolean(asString());
     }
 
     /**

--- a/ff4j-core/src/main/java/org/ff4j/strategy/PonderationStrategy.java
+++ b/ff4j-core/src/main/java/org/ff4j/strategy/PonderationStrategy.java
@@ -68,7 +68,7 @@ public class PonderationStrategy extends AbstractFlipStrategy implements Seriali
     public void init(String featureName, Map<String, String> initParams) {
         super.init(featureName, initParams);
         if (initParams != null && initParams.containsKey(PARAM_WEIGHT)) {
-            this.weight = Double.valueOf(initParams.get(PARAM_WEIGHT)).doubleValue();
+            this.weight = Double.parseDouble(initParams.get(PARAM_WEIGHT));
         }
         checkWeight();
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2130 - Parsing should be used to convert "Strings" to primitives.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2130
Please let me know if you have any questions.
George Kankava