### PR TITLE
squid:S1118 Utility classes should not have public constructors

### DIFF
--- a/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
+++ b/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
@@ -39,11 +39,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class PropertyJsonParser {
+public final class PropertyJsonParser {
 
     /** Jackson mapper. */
     private static ObjectMapper objectMapper = new ObjectMapper();
-
+    
+    private PropertyJsonParser() {}
+    
     /**
      * Unmarshall {@link Feature} from json string.
      *

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleOperations.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleOperations.java
@@ -45,10 +45,12 @@ import org.ff4j.property.util.PropertyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ConsoleOperations implements ConsoleConstants {
+public final class ConsoleOperations implements ConsoleConstants {
     
     /** Logger for this class. */
     private static Logger LOGGER = LoggerFactory.getLogger(ConsoleOperations.class);
+    
+    private ConsoleOperations() {}
     
     /**
      * User action to create a new Feature.

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleRenderer.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleRenderer.java
@@ -87,7 +87,9 @@ public final class ConsoleRenderer implements ConsoleConstants {
         uxTypes.put("LogLevel", PropertyLogLevel.class.getName());
         uxTypes.put(String.class.getSimpleName(), PropertyString.class.getName());
     }
-
+    
+    private ConsoleRenderer() {}
+    
     /**
      * Render the ff4f console webpage through different block.
      * 

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/FF4jSwaggerConfiguration.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/FF4jSwaggerConfiguration.java
@@ -29,9 +29,11 @@ import io.swagger.jaxrs.config.BeanConfig;
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class FF4jSwaggerConfiguration {
+public final class FF4jSwaggerConfiguration {
     
     private static BeanConfig beanConfig;
+    
+    private FF4jSwaggerConfiguration() {}
     
     static {
         beanConfig = new BeanConfig();

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextHolder.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextHolder.java
@@ -28,10 +28,12 @@ import javax.ws.rs.core.SecurityContext;
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class FF4JSecurityContextHolder {
+public final class FF4JSecurityContextHolder {
 
     /** Put current security context as threadlocal to be reused by the AuthenticationProvider. */
     private static final ThreadLocal< SecurityContext > securityContextHolder = new ThreadLocal< SecurityContext >();
+    
+    private FF4JSecurityContextHolder() {}
     
     /**
      * Return custom FF4J Security Context.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava