### PR TITLE
Multiple code improvements - squid:S134, squid:UselessParenthesesCheck

### DIFF
--- a/ff4j-utils-json/src/main/java/org/ff4j/utils/json/FeatureJsonParser.java
+++ b/ff4j-utils-json/src/main/java/org/ff4j/utils/json/FeatureJsonParser.java
@@ -111,22 +111,26 @@ public class FeatureJsonParser {
                 Property<?> ap = PropertyFactory.createProperty(propertyName, propertyType, propertyVal);
                 // FixedValued
                 List <Object> listOfFixedValue = (List<Object>) propertyJson.get("fixedValues");
-                if (listOfFixedValue != null) {
-                    for (Object v : listOfFixedValue) {
-                        ap.add2FixedValueFromString(String.valueOf(v));
-                    }
-                    // Check fixed value
-                    if (ap.getFixedValues() != null && !ap.getFixedValues().contains(ap.getValue())) {
-                        throw new IllegalArgumentException("Cannot create property <" + ap.getName() + 
-                                "> invalid value <" + ap.getValue() + 
-                                "> expected one of " + ap.getFixedValues());
-                    }
-                }
+                addFixedValuesToProperty(ap, listOfFixedValue);
                 myProperties.put(ap.getName(), ap);
             }
         }
         return myProperties;
         
+    }
+
+    private static void addFixedValuesToProperty(Property<?> ap, List<Object> listOfFixedValue) {
+        if (listOfFixedValue != null) {
+            for (Object v : listOfFixedValue) {
+                ap.add2FixedValueFromString(String.valueOf(v));
+            }
+            // Check fixed value
+            if (ap.getFixedValues() != null && !ap.getFixedValues().contains(ap.getValue())) {
+                throw new IllegalArgumentException("Cannot create property <" + ap.getName() + 
+                        "> invalid value <" + ap.getValue() + 
+                        "> expected one of " + ap.getFixedValues());
+            }
+        }
     }
 
     /**

--- a/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
+++ b/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
@@ -119,9 +119,9 @@ public final class PropertyJsonParser {
     public static Property<?> parsePropertyMap(Map<String, Object> fMap) {
         PropertyJsonBean pf = new PropertyJsonBean();
         pf.setName((String) fMap.get("name"));
-        pf.setDescription(((String) fMap.get("description")));
-        pf.setType(((String) fMap.get("type")));
-        pf.setValue(((String) fMap.get("value")));
+        pf.setDescription((String) fMap.get("description"));
+        pf.setType((String) fMap.get("type"));
+        pf.setValue((String) fMap.get("value"));
         if (fMap.containsKey("fixedValues")) {
             List < String > dbList = (ArrayList<String>) fMap.get("fixedValues");
             if (dbList != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S134 - Control flow statements "if", "for", "while", "switch" and "try" should not be nested too deeply.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S134
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava