### PR TITLE
squid:S00122 - Statements should be on separate lines

### DIFF
--- a/ff4j-utils-json/src/main/java/org/ff4j/utils/json/FeatureJsonParser.java
+++ b/ff4j-utils-json/src/main/java/org/ff4j/utils/json/FeatureJsonParser.java
@@ -162,7 +162,9 @@ public class FeatureJsonParser {
      */
     @SuppressWarnings("unchecked")
     public static FlippingStrategy parseFlipStrategyAsJson(String uid, String json) {
-        if (null == json || "".equals(json)) return null;
+        if (null == json || "".equals(json)) {
+            return null;
+        }
         try {
             return parseFlipStrategy(uid, (HashMap<String, Object>) objectMapper.readValue(json, HashMap.class));
         } catch (Exception e) {
@@ -181,7 +183,9 @@ public class FeatureJsonParser {
      */
     @SuppressWarnings("unchecked")
     public static FlippingStrategy parseFlipStrategy(String uid, HashMap<String, Object> flipMap) {
-        if (null == flipMap || flipMap.isEmpty()) return null;
+        if (null == flipMap || flipMap.isEmpty()) {
+            return null;
+        }
         String classType = (String) flipMap.get("type");
         HashMap<String, String> initparams = (HashMap<String, String>) flipMap.get("initParams");
         return MappingUtil.instanceFlippingStrategy(uid, classType, initparams);
@@ -197,7 +201,9 @@ public class FeatureJsonParser {
      */
     @SuppressWarnings("unchecked")
     public static Feature[] parseFeatureArray(String json) {
-        if (null == json || "".equals(json)) return null;
+        if (null == json || "".equals(json)) {
+            return null;
+        }
         try {
             List<LinkedHashMap<String, Object>> flipMap = objectMapper.readValue(json, List.class);
             Feature[] fArray = new Feature[flipMap.size()];

--- a/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
+++ b/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
@@ -55,7 +55,9 @@ public final class PropertyJsonParser {
      */
     @SuppressWarnings("unchecked")
     public static Property<?> parseProperty(String json) {
-        if (null == json || "".equals(json)) return null;
+        if (null == json || "".equals(json)) {
+            return null;
+        }
         Map<String, Object> propertyJson;
         try {
             propertyJson = objectMapper.readValue(json, HashMap.class);
@@ -93,7 +95,9 @@ public final class PropertyJsonParser {
      */
     @SuppressWarnings("unchecked")
     public static Property<?>[] parsePropertyArray(String json) {
-        if (null == json || "".equals(json)) return null;
+        if (null == json || "".equals(json)) {
+            return null;
+        }
         try {
             List<LinkedHashMap<String, Object>> flipMap = objectMapper.readValue(json, List.class);
             Property<?>[] fArray = new Property<?>[flipMap.size()];


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S00122 - Statements should be on separate lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00122
Please let me know if you have any questions.
George Kankava