### PR TITLE
Multiple code improvements - squid:S1905, squid:S1155, squid:UselessParenthesesCheck

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -545,13 +545,13 @@ public class FF4j {
         StringBuilder sb = new StringBuilder("{");
         // Render Uptime as String "X day(s) X hours(s) X minute(s) X seconds"
         long uptime = System.currentTimeMillis() - startTime;
-        long daynumber = (long) uptime / (1000 * 3600 * 24);
-        uptime = uptime - (daynumber * 1000 * 3600 * 24);
-        long hourNumber = (long) uptime / (1000 * 3600);
-        uptime = uptime - (hourNumber * 1000 * 3600);
-        long minutenumber = (long) uptime / (1000 * 60);
-        uptime = uptime - (minutenumber * 1000 * 60);
-        long secondnumber = (long) uptime / 1000;
+        long daynumber = uptime / (1000 * 3600 * 24L);
+        uptime = uptime - daynumber * 1000 * 3600 * 24L;
+        long hourNumber = uptime / (1000 * 3600L);
+        uptime = uptime - hourNumber * 1000 * 3600L;
+        long minutenumber = uptime / (1000 * 60L);
+        uptime = uptime - minutenumber * 1000 * 60L;
+        long secondnumber = uptime / 1000L;
         sb.append("\"uptime\":\"");
         sb.append(daynumber + " day(s) ");
         sb.append(hourNumber + " hours(s) ");

--- a/ff4j-core/src/main/java/org/ff4j/cache/FF4jCacheProxy.java
+++ b/ff4j-core/src/main/java/org/ff4j/cache/FF4jCacheProxy.java
@@ -333,7 +333,7 @@ public class FF4jCacheProxy implements FeatureStore, PropertyStore {
     @Override
     public boolean isEmpty() {
         Set<String> pNames = listPropertyNames();
-        return pNames != null && pNames.size() > 0;
+        return pNames != null && !pNames.isEmpty();
     }
 
     /** {@inheritDoc} */

--- a/ff4j-core/src/main/java/org/ff4j/property/store/AbstractPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/AbstractPropertyStore.java
@@ -70,7 +70,7 @@ public abstract class AbstractPropertyStore implements PropertyStore {
     /** {@inheritDoc} */
     public boolean isEmpty() {
         Set < String > pNames = listPropertyNames();
-        return pNames == null || pNames.size() == 0;
+        return pNames == null || pNames.isEmpty();
     }
     
     /** {@inheritDoc} */

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -115,7 +115,7 @@ public class JdbcPropertyStore extends AbstractPropertyStore implements JdbcStor
             ps.setString(2, ap.getType());
             ps.setString(3, ap.asString());
             ps.setString(4, ap.getDescription());
-            if (ap.getFixedValues() != null && ap.getFixedValues().size() > 0) {
+            if (ap.getFixedValues() != null && !ap.getFixedValues().isEmpty()) {
                 String fixedValues = ap.getFixedValues().toString();
                 ps.setString(5, fixedValues.substring(1, fixedValues.length() - 1));
             } else {

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -532,7 +532,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
         ps.setString(2, pp.getType());
         ps.setString(3, pp.asString());
         ps.setString(4, pp.getDescription());
-        if (pp.getFixedValues() != null && pp.getFixedValues().size() > 0) {
+        if (pp.getFixedValues() != null && !pp.getFixedValues().isEmpty()) {
             String fixedValues = pp.getFixedValues().toString();
             ps.setString(5, fixedValues.substring(1, fixedValues.length() - 1));
         } else {


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rules
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1905 - Redundant casts should not be used.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
George Kankava