### PR TITLE
Multiple code improvements - squid:S1319, squid:S1149, squid:S2583, squid:UselessParenthesesCheck

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAutoProxy.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAutoProxy.java
@@ -66,7 +66,7 @@ public class FeatureAutoProxy extends AbstractAutoProxyCreator {
                     return PROXY_WITHOUT_ADDITIONAL_INTERCEPTORS;
                 }
             } else {
-               if ((currentInterface != null) && (currentInterface.isAnnotationPresent(Flip.class))) {
+               if (currentInterface.isAnnotationPresent(Flip.class)) {
                    // If annotation is registered on Interface class 
                    processedInterface.put(currentInterfaceName, true);
                     return PROXY_WITHOUT_ADDITIONAL_INTERCEPTORS;

--- a/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/FF4jPropertiesPlaceHolderConfigurer.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/FF4jPropertiesPlaceHolderConfigurer.java
@@ -70,7 +70,7 @@ public class FF4jPropertiesPlaceHolderConfigurer implements BeanFactoryPostProce
             // 2) Inject property & features value
             String[] beanNames = beanFactory.getBeanDefinitionNames();
             for (int i = 0; i < beanNames.length; i++) {
-                if (beanNames[i].equals(beanName) && beanFactory.equals(beanFactory)) {
+                if (beanNames[i].equals(beanName)) {
                     continue;
                 }
                 BeanDefinition bd = beanFactory.getBeanDefinition(beanNames[i]);

--- a/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/PropertiesPlaceHolderBeanDefinitionVisitor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/PropertiesPlaceHolderBeanDefinitionVisitor.java
@@ -90,14 +90,14 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
      */
     protected String parseStringValue(String strVal, Map<String, Property<?>> propertiesMap, Map<String, Feature> featureMap, Set<String> visitedPlaceholders) 
     throws BeanDefinitionStoreException {
-        StringBuffer buf = new StringBuffer(strVal);
+        StringBuilder builder = new StringBuilder(strVal);
         
         // @ff4jProperty{}
         int startIndex = strVal.indexOf(PLACEHOLDER_PROPERTY_PREFIX);
         while (startIndex != -1) {
-            int endIndex = buf.toString().indexOf(PLACEHOLDER_SUFFIX, startIndex + PLACEHOLDER_PROPERTY_PREFIX.length());
+            int endIndex = builder.toString().indexOf(PLACEHOLDER_SUFFIX, startIndex + PLACEHOLDER_PROPERTY_PREFIX.length());
             if (endIndex != -1) {
-                String placeholder = buf.substring(startIndex + PLACEHOLDER_PROPERTY_PREFIX.length(), endIndex);
+                String placeholder = builder.substring(startIndex + PLACEHOLDER_PROPERTY_PREFIX.length(), endIndex);
                 if (!visitedPlaceholders.add(placeholder)) {
                     throw new BeanDefinitionStoreException("Circular placeholder reference '" + placeholder + "' in property definitions");
                 }
@@ -108,11 +108,11 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
                 String propVal = propertiesMap.get(placeholder).asString();
                 if (propVal != null) {
                     propVal = parseStringValue(propVal, propertiesMap, featureMap, visitedPlaceholders);
-                    buf.replace(startIndex, endIndex + PLACEHOLDER_SUFFIX.length(), propVal);
+                    builder.replace(startIndex, endIndex + PLACEHOLDER_SUFFIX.length(), propVal);
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Resolved placeholder '{}' to value '{}'", placeholder, propVal);
                     }
-                    startIndex = buf.toString().indexOf(PLACEHOLDER_PROPERTY_PREFIX, startIndex + propVal.length());
+                    startIndex = builder.toString().indexOf(PLACEHOLDER_PROPERTY_PREFIX, startIndex + propVal.length());
                 } else {
                     throw new BeanDefinitionStoreException("Could not resolve placeholder '" + placeholder + "'");
                 }
@@ -125,9 +125,9 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
         // @ff4jFeature{}
         startIndex = strVal.indexOf(PLACEHOLDER_FEATURE_PREFIX);
         while (startIndex != -1) {
-            int endIndex = buf.toString().indexOf(PLACEHOLDER_SUFFIX, startIndex + PLACEHOLDER_FEATURE_PREFIX.length());
+            int endIndex = builder.toString().indexOf(PLACEHOLDER_SUFFIX, startIndex + PLACEHOLDER_FEATURE_PREFIX.length());
             if (endIndex != -1) {
-                String placeholder = buf.substring(startIndex + PLACEHOLDER_FEATURE_PREFIX.length(), endIndex);
+                String placeholder = builder.substring(startIndex + PLACEHOLDER_FEATURE_PREFIX.length(), endIndex);
                 if (!visitedPlaceholders.add(placeholder)) {
                     throw new BeanDefinitionStoreException("Circular placeholder reference '" + placeholder + "' in property definitions");
                 }
@@ -138,11 +138,11 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
                 String propVal = String.valueOf(featureMap.get(placeholder).isEnable());
                 if (propVal != null) {
                     propVal = parseStringValue(propVal, propertiesMap, featureMap, visitedPlaceholders);
-                    buf.replace(startIndex, endIndex + PLACEHOLDER_FEATURE_PREFIX.length(), propVal);
+                    builder.replace(startIndex, endIndex + PLACEHOLDER_FEATURE_PREFIX.length(), propVal);
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Resolved placeholder '{}' to value '{}'", placeholder, propVal);
                     }
-                    startIndex = buf.toString().indexOf(PLACEHOLDER_FEATURE_PREFIX, startIndex + propVal.length());
+                    startIndex = builder.toString().indexOf(PLACEHOLDER_FEATURE_PREFIX, startIndex + propVal.length());
                 } else {
                     throw new BeanDefinitionStoreException("Could not resolve placeholder '" + placeholder + "'");
                 }
@@ -152,7 +152,7 @@ public class PropertiesPlaceHolderBeanDefinitionVisitor extends BeanDefinitionVi
             }
         }
         
-        return buf.toString();
+        return builder.toString();
     }
     
 }

--- a/ff4j-core/src/main/java/org/ff4j/utils/Util.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/Util.java
@@ -54,7 +54,7 @@ public class Util {
      *            expression to evaluate
      */
     public static boolean hasLength(String expression) {
-        return (expression != null && !"".equals(expression));
+        return expression != null && !"".equals(expression);
     }
     
    /**

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/store/PropertyStoreEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/store/PropertyStoreEhCache.java
@@ -72,7 +72,7 @@ public class PropertyStoreEhCache extends AbstractPropertyStore {
     @Override
     public boolean existProperty(String name) {
         Util.assertParamNotNull(name, "Property name");
-        return  (wrapper.getCacheProperties().get(name) != null);
+        return  wrapper.getCacheProperties().get(name) != null;
     }
 
     /** {@inheritDoc} */

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
@@ -196,9 +196,9 @@ public final class FeatureDocumentMapper implements FeatureStoreMongoConstants {
     public Property< ? > mapProperty(DBObject dbObject) {
         PropertyJsonBean pf = new PropertyJsonBean();
         pf.setName((String) dbObject.get(PROPERTY_NAME));
-        pf.setDescription(((String) dbObject.get(PROPERTY_DESCRIPTION)));
-        pf.setType(((String) dbObject.get(PROPERTY_TYPE)));
-        pf.setValue(((String) dbObject.get(PROPERTY_VALUE)));
+        pf.setDescription((String) dbObject.get(PROPERTY_DESCRIPTION));
+        pf.setType((String) dbObject.get(PROPERTY_TYPE));
+        pf.setValue((String) dbObject.get(PROPERTY_VALUE));
         if (dbObject.containsField(PROPERTY_FIXEDVALUES)) {
             BasicDBList dbList = (BasicDBList) dbObject.get(PROPERTY_FIXEDVALUES);
             if (dbList != null) {

--- a/ff4j-utils-json/src/main/java/org/ff4j/utils/json/FeatureJsonParser.java
+++ b/ff4j-utils-json/src/main/java/org/ff4j/utils/json/FeatureJsonParser.java
@@ -186,7 +186,7 @@ public class FeatureJsonParser {
      * @return flip strategy
      */
     @SuppressWarnings("unchecked")
-    public static FlippingStrategy parseFlipStrategy(String uid, HashMap<String, Object> flipMap) {
+    public static FlippingStrategy parseFlipStrategy(String uid, Map<String, Object> flipMap) {
         if (null == flipMap || flipMap.isEmpty()) {
             return null;
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S2583
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava