### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
@@ -48,6 +48,7 @@ import org.ff4j.utils.Util;
  */
 public class JdbcEventRepository extends AbstractEventRepository implements JdbcStoreConstants {
 
+    public static final String CANNOT_BUILD_PIE_CHART_FROM_REPOSITORY = "Cannot build PieChart from repository, ";
     /** Access to storage. */
     private DataSource dataSource;
 
@@ -205,7 +206,7 @@ public class JdbcEventRepository extends AbstractEventRepository implements Jdbc
             }
             
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot build PieChart from repository, ", sqlEX);
+            throw new FeatureAccessException(CANNOT_BUILD_PIE_CHART_FROM_REPOSITORY, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);
@@ -251,7 +252,7 @@ public class JdbcEventRepository extends AbstractEventRepository implements Jdbc
             }
                 
         } catch (SQLException sqlEX) {
-            throw new AuditAccessException("Cannot build PieChart from repository, ", sqlEX);
+            throw new AuditAccessException(CANNOT_BUILD_PIE_CHART_FROM_REPOSITORY, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);
@@ -289,7 +290,7 @@ public class JdbcEventRepository extends AbstractEventRepository implements Jdbc
             return pieGraph;
                 
         } catch (SQLException sqlEX) {
-            throw new AuditAccessException("Cannot build PieChart from repository, ", sqlEX);
+            throw new AuditAccessException(CANNOT_BUILD_PIE_CHART_FROM_REPOSITORY, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);

--- a/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
+++ b/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
@@ -169,7 +169,8 @@ public final class XmlParser {
     
     /** XML Generation constants. */
     private static final String END_FF4J = "</ff4j>\n\n";
-    
+    public static final String ERROR_SYNTAX_IN_CONFIGURATION_FILE = "Error syntax in configuration file : ";
+
     /** Document Builder use to parse XML. */
     private static DocumentBuilder builder = null;
    
@@ -279,12 +280,12 @@ public final class XmlParser {
         // Identifier
         String uid;
         if (nnm.getNamedItem(FEATURE_ATT_UID) == null) {
-            throw new IllegalArgumentException("Error syntax in configuration file : " + "'uid' is required for each feature");
+            throw new IllegalArgumentException(ERROR_SYNTAX_IN_CONFIGURATION_FILE + "'uid' is required for each feature");
         }
         uid = nnm.getNamedItem(FEATURE_ATT_UID).getNodeValue();
         // Enable
         if (nnm.getNamedItem(FEATURE_ATT_ENABLE) == null) {
-            throw new IllegalArgumentException("Error syntax in configuration file : "
+            throw new IllegalArgumentException(ERROR_SYNTAX_IN_CONFIGURATION_FILE
                     + "'enable' is required for each feature (check " + uid + ")");
         }
         boolean enable = Boolean.parseBoolean(nnm.getNamedItem(FEATURE_ATT_ENABLE).getNodeValue());
@@ -414,7 +415,7 @@ public final class XmlParser {
                 // Check for required attribute name
                 String currentParamName;
                 if (nnmap.getNamedItem(FLIPSTRATEGY_PARAMNAME) == null) {
-                    throw new IllegalArgumentException("Error syntax in configuration file : "
+                    throw new IllegalArgumentException(ERROR_SYNTAX_IN_CONFIGURATION_FILE
                             + "'name' is required for each param in flipstrategy(check " + uid + ")");
                 }
                 currentParamName = nnmap.getNamedItem(FLIPSTRATEGY_PARAMNAME).getNodeValue();

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -59,6 +59,8 @@ import org.ff4j.utils.Util;
  */
 public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStoreConstants {
 
+    public static final String CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE = "Cannot check feature existence, error related to database";
+    public static final String CANNOT_UPDATE_FEATURES_DATABASE_SQL_ERROR = "Cannot update features database, SQL ERROR";
     /** Access to storage. */
     private DataSource dataSource;
     
@@ -119,7 +121,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             rs.next();
             return 1 == rs.getInt(1);
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);
@@ -168,7 +170,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             }
             return f;
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);
@@ -230,7 +232,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
 
         } catch (SQLException sqlEX) {
             rollback(sqlConn);
-            throw new FeatureAccessException("Cannot update features database, SQL ERROR", sqlEX);
+            throw new FeatureAccessException(CANNOT_UPDATE_FEATURES_DATABASE_SQL_ERROR, sqlEX);
         } finally {
             closeStatement(ps);
             closeConnection(sqlConn);
@@ -279,7 +281,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
 
         } catch (SQLException sqlEX) {
             rollback(sqlConn);
-            throw new FeatureAccessException("Cannot update features database, SQL ERROR", sqlEX);
+            throw new FeatureAccessException(CANNOT_UPDATE_FEATURES_DATABASE_SQL_ERROR, sqlEX);
         } finally {
             closeStatement(ps);
             closeConnection(sqlConn);
@@ -325,7 +327,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             return mapFP;
 
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);
@@ -411,7 +413,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
                 createCustomProperties(fp.getUid(), fp.getCustomProperties().values());
             } 
             } catch (SQLException sqlEX) {
-                throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+                throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
             } finally {
                 closeStatement(ps);
                 closeConnection(sqlConn);
@@ -438,7 +440,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             ps.executeUpdate();
             
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeStatement(ps);
             closeConnection(sqlConn);
@@ -475,7 +477,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             sqlConn.commit();
             
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeStatement(ps);
             closeConnection(sqlConn);
@@ -528,7 +530,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             rs.next(); 
             return rs.getInt(1) > 0;
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);
@@ -581,7 +583,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             return mapFP;
 
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot check feature existence, error related to database", sqlEX);
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeResultSet(rs);
             closeStatement(ps);
@@ -623,7 +625,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStore
             ps = buildStatement(sqlConnection, query, params);
             ps.executeUpdate();
         } catch (SQLException sqlEX) {
-            throw new FeatureAccessException("Cannot update features database, SQL ERROR", sqlEX);
+            throw new FeatureAccessException(CANNOT_UPDATE_FEATURES_DATABASE_SQL_ERROR, sqlEX);
         } finally {
             closeStatement(ps);
             closeConnection(sqlConnection);

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcStoreConstants.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcStoreConstants.java
@@ -177,12 +177,12 @@ public interface JdbcStoreConstants {
      
     /** Creation. */
     String SQL_AUDIT_COUNT = "SELECT COUNT(*) FROM " + TABLE_AUDIT;
-    
+
     /** Creation. */
     String SQL_AUDIT_LISTFEATURES = "SELECT DISTINCT " + COL_EVENT_NAME + " FROM " + TABLE_AUDIT + " WHERE " + COL_EVENT_TYPE + " LIKE '" + EventConstants.TARGET_FEATURE + "'";
-    
+
     /** Get all information for the Pie as a single request. */
-    String SQL_AUDIT_OK_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_NAME + 
+    String SQL_AUDIT_OK_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_NAME +
                                   " FROM " + TABLE_AUDIT +
                                   " WHERE (" + COL_EVENT_TYPE   + " LIKE '" + EventConstants.TARGET_FEATURE  + "') " +
                                   " AND   (" + COL_EVENT_ACTION + " LIKE '" + EventConstants.ACTION_CHECK_OK + "') " +
@@ -191,8 +191,8 @@ public interface JdbcStoreConstants {
                                   " GROUP BY " + COL_EVENT_NAME;
     
     /** List events for a dedicate feature (in a time window). */
-    String SQL_AUDIT_FEATURE_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_ACTION + 
-                                     " FROM " + TABLE_AUDIT  + 
+    String SQL_AUDIT_FEATURE_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_ACTION +
+                                     " FROM " + TABLE_AUDIT  +
                                      " WHERE (" + COL_EVENT_TYPE + " LIKE '" + EventConstants.TARGET_FEATURE  + "') " +
                                      " AND   (" + COL_EVENT_NAME + " LIKE ?) " +  
                                      " AND   (" + COL_EVENT_TIME + "> ?) " + 

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/FeatureStoreMongoCollection.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/FeatureStoreMongoCollection.java
@@ -41,6 +41,8 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
 
     /** Build fields. */
     private static final FeatureDocumentBuilder BUILDER = new FeatureDocumentBuilder();
+    public static final String FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY = "Feature identifier cannot be null nor empty";
+    public static final String GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY = "Groupname cannot be null nor empty";
 
     /** MongoDB collection. */
     private final MongoCollection<Document> collection;
@@ -88,7 +90,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
      */
     private void updateStatus(String uid, boolean enable) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);
@@ -109,7 +111,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public Feature read(String uid) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         Document object = collection.find(BUILDER.getFeatUid(uid)).first();
         if (object==null) {
@@ -134,7 +136,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public void delete(String uid) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);
@@ -146,7 +148,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public void grantRoleOnFeature(String uid, String roleName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (roleName == null || roleName.isEmpty()) {
             throw new IllegalArgumentException("roleName cannot be null nor empty");
@@ -161,7 +163,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public void removeRoleFromFeature(String uid, String roleName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (roleName == null || roleName.isEmpty()) {
             throw new IllegalArgumentException("roleName cannot be null nor empty");
@@ -197,7 +199,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public boolean existGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         return collection.count(BUILDER.getGroupName(groupName)) > 0;
     }
@@ -218,7 +220,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public Map<String, Feature> readGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -235,7 +237,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public void enableGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -250,7 +252,7 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public void disableGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -265,10 +267,10 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public void addToGroup(String uid, String groupName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);
@@ -282,10 +284,10 @@ public class FeatureStoreMongoCollection extends AbstractFeatureStore implements
     @Override
     public void removeFromGroup(String uid, String groupName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/FeatureStoreMongoDB.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/FeatureStoreMongoDB.java
@@ -44,6 +44,8 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
 
     /** Build fields. */
     private static final FeatureDBObjectBuilder BUILDER = new FeatureDBObjectBuilder();
+    public static final String FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY = "Feature identifier cannot be null nor empty";
+    public static final String GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY = "Groupname cannot be null nor empty";
 
     /** MongoDB collection. */
     private final DBCollection collection;
@@ -91,7 +93,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
      */
     private void updateStatus(String uid, boolean enable) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);
@@ -112,7 +114,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public Feature read(String uid) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         DBObject object = collection.findOne(BUILDER.getFeatUid(uid));
         if (object==null) {
@@ -137,7 +139,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public void delete(String uid) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);
@@ -149,7 +151,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public void grantRoleOnFeature(String uid, String roleName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (roleName == null || roleName.isEmpty()) {
             throw new IllegalArgumentException("roleName cannot be null nor empty");
@@ -164,7 +166,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public void removeRoleFromFeature(String uid, String roleName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (roleName == null || roleName.isEmpty()) {
             throw new IllegalArgumentException("roleName cannot be null nor empty");
@@ -200,7 +202,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public boolean existGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         return collection.count(BUILDER.getGroupName(groupName)) > 0;
     }
@@ -221,7 +223,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public Map<String, Feature> readGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -238,7 +240,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public void enableGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -253,7 +255,7 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public void disableGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -268,10 +270,10 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public void addToGroup(String uid, String groupName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);
@@ -285,10 +287,10 @@ public class FeatureStoreMongoDB extends AbstractFeatureStore implements Feature
     @Override
     public void removeFromGroup(String uid, String groupName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/FF4jNeo4jConstants.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/FF4jNeo4jConstants.java
@@ -74,49 +74,52 @@ public interface FF4jNeo4jConstants {
     // -------------------------------------------------------
     // --------------------- Create  -------------------------  
     // -------------------------------------------------------
-    
+
+    String MATCH_F = "MATCH (f:";
     /** Cypher query. */
     String QUERY_CYPHER_ADDTO_GROUP = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + "  {uid: {uid} } ), " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + "  {uid: {uid} } ), " +
             "(g:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + " {name: {groupName} }) " + 
             "CREATE (f)-[:" + FF4jNeo4jRelationShips.MEMBER_OF + "]->(g);";
     
     // -------------------------------------------------------
     // --------------------- Read ----------------------------
     // -------------------------------------------------------
-    
+
+    String RETURN_COUNT_AS = "RETURN count(*) AS ";
     /** Cypher query. */
     String QUERY_CYPHER_EXISTS  = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid:  {uid} }) " + 
-            "RETURN count(*) AS " + QUERY_CYPHER_ALIAS;
-    
-    String QUERY_CYPHER_EXISTS_PROPERTY  = 
-            "MATCH (p:" + FF4jNeo4jLabels.FF4J_PROPERTY + " { name:  {name} }) " + 
-            "RETURN count(*) AS " + QUERY_CYPHER_ALIAS;
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid:  {uid} }) " +
+                    RETURN_COUNT_AS + QUERY_CYPHER_ALIAS;
+
+    String MATCH_P = "MATCH (p:";
+    String QUERY_CYPHER_EXISTS_PROPERTY  =
+            MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name:  {name} }) " +
+                    RETURN_COUNT_AS + QUERY_CYPHER_ALIAS;
     
     String QUERY_CYPHER_EXISTS_GROUP =
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + " { name:  {groupName} }) " + 
-            "RETURN count(*) AS " + QUERY_CYPHER_ALIAS;
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + " { name:  {groupName} }) " +
+                    RETURN_COUNT_AS + QUERY_CYPHER_ALIAS;
             
     /** Cypher query. */
     String QUERY_CYPHER_READ_FEATURE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(all) RETURN f,all";
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(all) RETURN f,all";
     
     /** Cypher query. */
     String QUERY_CYPHER_READ_PROPERTY = 
-            "MATCH (p:" + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name} }) RETURN p";
+            MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name} }) RETURN p";
     
     /** Cypher query. */
     String QUERY_CYPHER_NORELATIONSHIPS = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) RETURN f;";
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) RETURN f;";
     
     /** Cypher query. */
     String QUERY_CYPHER_READ_ALL = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + ")--(all) RETURN f,all;";
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + ")--(all) RETURN f,all;";
     
     /** Cypher query. */
     String QUERY_CYPHER_READ_ALLPROPERTIES = 
-            "MATCH (p:" + FF4jNeo4jLabels.FF4J_PROPERTY + ") RETURN p;";
+            MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + ") RETURN p;";
     
     /** Cypher query. */
     String QUERY_CYPHER_READ_SINGLE = 
@@ -130,20 +133,22 @@ public interface FF4jNeo4jConstants {
     
     /** Cypher query. */
     String QUERY_CYPHER_GET_FLIPPINGSTRATEGY = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })" + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })" +
             "--(s:" + FF4jNeo4jLabels.FF4J_FLIPPING_STRATEGY + ") " + 
             "RETURN s;";
-    
+
+    String NAME_GROUP_NAME = "]-( { name: {groupName} }) ";
+    String WHERE_F = "WHERE (f)-[:";
     /** Cypher query. */
     String QUERY_CYPHER_COUNT_FEATURE_OF_GROUP = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " ) " + 
-            "WHERE (f)-[:" + FF4jNeo4jRelationShips.MEMBER_OF + "]-( { name: {groupName} }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
+                    WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "RETURN COUNT(*) AS " + QUERY_CYPHER_ALIAS + ";";
     
     /** Cypher query. */
     String QUERY_CYPHER_READ_FEATURES_OF_GROUP = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " ) " + 
-            "WHERE (f)-[:" + FF4jNeo4jRelationShips.MEMBER_OF + "]-( { name: {groupName} }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
+                    WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "RETURN f.uid AS UID;";
     
     /** Cypher query. */
@@ -153,7 +158,7 @@ public interface FF4jNeo4jConstants {
     
     /** Cypher query. */
     String QUERY_READ_PROPERTYNAMES = 
-            "MATCH (p:" +  FF4jNeo4jLabels.FF4J_PROPERTY + "  ) " + 
+            MATCH_P +  FF4jNeo4jLabels.FF4J_PROPERTY + "  ) " +
             "RETURN p.name AS NAME;";
     
     // -------------------------------------------------------
@@ -162,35 +167,35 @@ public interface FF4jNeo4jConstants {
     
     /** Cypher query. */
     String QUERY_CYPHER_ENABLE  = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) " +
             "SET f.enable = true RETURN f.enable;";
     
     
     /** Cypher query. */
     String QUERY_CYPHER_UPDATE_PROPERTYVALUE  = 
-            "MATCH (p:" + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name} }) " + 
+            MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name} }) " +
             "SET p." + NODEPROPERTY_ATT_VALUE + "= {value};";
     
     /** Cypher query. */
     String QUERY_CYPHER_DISABLE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) " +
             "SET f.enable = false RETURN f.enable;";
     
     /** Cypher query. */
     String QUERY_CYPHER_ADD_ROLE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + "  {uid: {uid} }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + "  {uid: {uid} }) " +
             "SET f.roles = f.roles + {roleName} return f;";
     
     /** Cypher query. */
     String QUERY_CYPHER_ENABLE_GROUP = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " ) " + 
-            "WHERE (f)-[:" + FF4jNeo4jRelationShips.MEMBER_OF + "]-( { name: {groupName} }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
+                    WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "SET f.enable = true RETURN f.enable;";
     
     /** Cypher query. */
     String QUERY_CYPHER_DISABLE_GROUP = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " ) " + 
-            "WHERE (f)-[:" + FF4jNeo4jRelationShips.MEMBER_OF + "]-( { name: {groupName} }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
+                    WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "SET f.enable = false RETURN f.enable;";
     
     /** Cypher query. */
@@ -204,32 +209,32 @@ public interface FF4jNeo4jConstants {
     
     /** Delete properties related to the feature. */
     String QUERY_CYPHER_DELETE_PROPERTIES_FEATURE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(p:" + FF4jNeo4jLabels.FF4J_FEATURE_PROPERTY + " ) "  + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(p:" + FF4jNeo4jLabels.FF4J_FEATURE_PROPERTY + " ) "  +
             "DETACH DELETE p;";
     
     /** Delete flipping strategy related to the feature. */
     String QUERY_CYPHER_DELETE_STRATEGY_FEATURE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(s:" + FF4jNeo4jLabels.FF4J_FLIPPING_STRATEGY + ") "  + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(s:" + FF4jNeo4jLabels.FF4J_FLIPPING_STRATEGY + ") "  +
             "DETACH DELETE s;";
 
     /** Delete flipping strategy related to the feature. */
     String QUERY_CYPHER_DELETE_GROUP_FEATURE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(s:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + ") "  + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(s:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + ") "  +
             "DETACH DELETE s;";
     
     /** Delete Feature with all its relationships*/
     String QUERY_CYPHER_DELETE_FEATURE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid}  }) " + 
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid}  }) " +
             "DETACH DELETE f;";
     
     /** Delete property. */
     String QUERY_CYPHER_DELETE_PROPERTY = 
-            "MATCH (p:" + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name}  }) " + 
+            MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name}  }) " +
                     "DETACH DELETE p;";
     
     /** Cypher query. */
     String QUERY_CYPHER_REMOVEFROMGROUP = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })-[a:" + FF4jNeo4jRelationShips.MEMBER_OF + "]->() DELETE a;";
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })-[a:" + FF4jNeo4jRelationShips.MEMBER_OF + "]->() DELETE a;";
     
     /** Cypher query. */
     String QUERY_CYPHER_DELETE_GROUP = 
@@ -241,10 +246,10 @@ public interface FF4jNeo4jConstants {
     
     /** Cypher query. */
     String QUERY_CYPHER_DELETE_ALLSINGLEFEATURE = 
-            "MATCH (f:" + FF4jNeo4jLabels.FF4J_FEATURE + ") DETACH DELETE f;";
+            MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + ") DETACH DELETE f;";
     
     /** Cypher query. */
     String QUERY_CYPHER_DELETE_ALLPROPERTY = 
-            "MATCH (p:" + FF4jNeo4jLabels.FF4J_PROPERTY + ") DETACH DELETE p;";
+            MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + ") DETACH DELETE p;";
 
 }

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/FeatureStoreNeo4J.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/FeatureStoreNeo4J.java
@@ -51,6 +51,8 @@ import org.neo4j.graphdb.Transaction;
  */
 public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4jConstants {
 
+    public static final String GROUPNAME = "GROUPNAME";
+    public static final String GROUP_NAME = "groupName";
     /** Persistent storage. */
     private GraphDatabaseService graphDb;
     
@@ -170,9 +172,9 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         // Check group
         Result result = graphDb.execute(QUERY_CYPHER_GETGROUPNAME, paramUID);
         if (result.hasNext()) {
-            String groupName = (String) result.next().get("GROUPNAME");
+            String groupName = (String) result.next().get(GROUPNAME);
             Map<String, Object> paramGroupName = new HashMap<>();
-            paramGroupName.put("groupName", groupName);
+            paramGroupName.put(GROUP_NAME, groupName);
             result = graphDb.execute(QUERY_CYPHER_COUNT_FEATURE_OF_GROUP, paramGroupName);
             if (result.hasNext()) {
                 long nbFeature = (long) result.next().get(QUERY_CYPHER_ALIAS);
@@ -320,7 +322,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         queryParameters.put("uid", uid);
         Result result = graphDb.execute(QUERY_CYPHER_GETGROUPNAME, queryParameters);
         if (result.hasNext()) {
-            groupName = (String) result.next().get("GROUPNAME");
+            groupName = (String) result.next().get(GROUPNAME);
         }
         tx.success();
         return groupName;
@@ -462,7 +464,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
     public boolean existGroup(String groupName) {
         Util.assertHasLength(groupName);
         Map < String, Object > queryParameters = new HashMap<>();
-        queryParameters.put("groupName", groupName);
+        queryParameters.put(GROUP_NAME, groupName);
         Result result = graphDb.execute(QUERY_CYPHER_EXISTS_GROUP,  queryParameters);
         Object count = null;
         if (result.hasNext()) {
@@ -479,7 +481,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         Map<String, Feature> groupFeatures = new HashMap<>();
         Transaction tx = graphDb.beginTx();
         Map<String, Object> paramGroupName = new HashMap<>();
-        paramGroupName.put("groupName", groupName);
+        paramGroupName.put(GROUP_NAME, groupName);
         Result result = graphDb.execute(QUERY_CYPHER_READ_FEATURES_OF_GROUP, paramGroupName);
         while (result.hasNext()) {
             String member = (String) result.next().get("UID");
@@ -495,7 +497,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         assertGroupExist(groupName);
         Transaction tx = graphDb.beginTx();
         Map<String, Object> paramGroupName = new HashMap<>();
-        paramGroupName.put("groupName", groupName);
+        paramGroupName.put(GROUP_NAME, groupName);
         graphDb.execute(QUERY_CYPHER_ENABLE_GROUP, paramGroupName);
         tx.success();
     }
@@ -506,7 +508,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         assertGroupExist(groupName);
         Transaction tx = graphDb.beginTx();
         Map<String, Object> paramGroupName = new HashMap<>();
-        paramGroupName.put("groupName", groupName);
+        paramGroupName.put(GROUP_NAME, groupName);
         graphDb.execute(QUERY_CYPHER_DISABLE_GROUP, paramGroupName);
         tx.success();
     }
@@ -530,7 +532,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         Transaction tx = graphDb.beginTx();
         Map<String, Object> params = new HashMap<>();
         params.put("uid", uid);
-        params.put("groupName", groupName);
+        params.put(GROUP_NAME, groupName);
         graphDb.execute(QUERY_CYPHER_ADDTO_GROUP, params);
         tx.success();
     }
@@ -556,7 +558,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         Result result = graphDb.execute(QUERY_READ_GROUPS);
         Set < String > response = new HashSet<>();
         while (result.hasNext()) {
-            response.add((String) result.next().get("GROUPNAME"));
+            response.add((String) result.next().get(GROUPNAME));
         }
         return response;
     }
@@ -622,7 +624,7 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4j
         Set < String > groupNames = readAllGroups();
         for (String groupName : groupNames) {
             Map < String, Object > paramGroupName = new HashMap<>();
-            paramGroupName.put("groupName", groupName);
+            paramGroupName.put(GROUP_NAME, groupName);
             Result result = graphDb.execute(QUERY_CYPHER_COUNT_FEATURE_OF_GROUP, paramGroupName);
             if (result.hasNext()) {
                 long nbFeature = (long) result.next().get(QUERY_CYPHER_ALIAS);

--- a/ff4j-store-redis/src/main/java/org/ff4j/cache/FeatureCacheProviderRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/cache/FeatureCacheProviderRedis.java
@@ -42,7 +42,8 @@ public class FeatureCacheProviderRedis implements FF4JCacheManager {
     
     /** prefix of keys. */
     public static final String KEY_PROPERTY = "FF4J_PROPERTY_";
-    
+    public static final String FEATURE_IDENTIFIER_PARAM_0_CANNOT_BE_NULL_NOR_EMPTY = "Feature identifier (param#0) cannot be null nor empty";
+
     /** default ttl. */
     private static int DEFAULT_TTL = 900000000;
     
@@ -88,7 +89,7 @@ public class FeatureCacheProviderRedis implements FF4JCacheManager {
     @Override
     public void evictFeature(String uid) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier (param#0) cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_PARAM_0_CANNOT_BE_NULL_NOR_EMPTY);
         }
         getJedis().del(KEY_FEATURE + uid);
     }
@@ -124,7 +125,7 @@ public class FeatureCacheProviderRedis implements FF4JCacheManager {
     @Override
     public Feature getFeature(String uid) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier (param#0) cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_PARAM_0_CANNOT_BE_NULL_NOR_EMPTY);
         }
         String value = getJedis().get(KEY_FEATURE + uid);
         if (value != null) {
@@ -137,7 +138,7 @@ public class FeatureCacheProviderRedis implements FF4JCacheManager {
     @Override
     public Property<?> getProperty(String propertyName) {
         if (propertyName == null || propertyName.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier (param#0) cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_PARAM_0_CANNOT_BE_NULL_NOR_EMPTY);
         }
         String value = getJedis().get(KEY_PROPERTY + propertyName);
         if (value != null) {

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/FeatureStoreSpringJdbc.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/FeatureStoreSpringJdbc.java
@@ -50,6 +50,8 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
 
     /** Mapper for custom properties. */
     private static final CustomPropertyRowMapper PMAPPER = new CustomPropertyRowMapper();
+    public static final String FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY = "Feature identifier cannot be null nor empty";
+    public static final String GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY = "Groupname cannot be null nor empty";
 
     /** SQL DataSource. */
     private DataSource dataSource;
@@ -225,7 +227,7 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Transactional
     public void grantRoleOnFeature(String uid, String roleName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (roleName == null || roleName.isEmpty()) {
             throw new IllegalArgumentException("roleName cannot be null nor empty");
@@ -241,7 +243,7 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Transactional
     public void removeRoleFromFeature(String uid, String roleName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (roleName == null || roleName.isEmpty()) {
             throw new IllegalArgumentException("roleName cannot be null nor empty");
@@ -257,7 +259,7 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Transactional
     public void enableGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -270,7 +272,7 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Transactional
     public void disableGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -282,7 +284,7 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Override
     public boolean existGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         int count = getJdbcTemplate().queryForObject(SQL_EXIST_GROUP, Integer.class, groupName);
         return count > 0;
@@ -292,7 +294,7 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Override
     public Map<String, Feature> readGroup(String groupName) {
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!existGroup(groupName)) {
             throw new GroupNotFoundException(groupName);
@@ -310,10 +312,10 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Transactional
     public void addToGroup(String uid, String groupName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);
@@ -326,10 +328,10 @@ public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements Jdbc
     @Transactional
     public void removeFromGroup(String uid, String groupName) {
         if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException("Feature identifier cannot be null nor empty");
+            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException("Groupname cannot be null nor empty");
+            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
         if (!exist(uid)) {
             throw new FeatureNotFoundException(uid);

--- a/ff4j-test/src/main/java/org/ff4j/test/AssertFf4j.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/AssertFf4j.java
@@ -33,6 +33,8 @@ import org.junit.Assert;
  */
 public class AssertFf4j {
 
+    public static final String IS_MANDATORY = "' is mandatory";
+    public static final String FEATURE = "Feature '";
     /** reference to ff4j context. */
     private final FF4j ff4j;
 
@@ -54,7 +56,7 @@ public class AssertFf4j {
      * @return current object
      */
     public final AssertFf4j assertThatFeatureExist(String featureName) {
-        Assert.assertTrue("Feature '" + featureName + "' is mandatory", ff4j.exist(featureName));
+        Assert.assertTrue(FEATURE + featureName + IS_MANDATORY, ff4j.exist(featureName));
         return this;
     }
     
@@ -66,7 +68,7 @@ public class AssertFf4j {
      * @return current object
      */
     public final AssertFf4j assertThatPropertyExist(String propertyName) {
-        Assert.assertTrue("Property '" + propertyName + "' is mandatory", ff4j.getPropertiesStore().existProperty(propertyName));
+        Assert.assertTrue("Property '" + propertyName + IS_MANDATORY, ff4j.getPropertiesStore().existProperty(propertyName));
         return this;
     }
 
@@ -78,7 +80,7 @@ public class AssertFf4j {
      * @return current object
      */
     public final AssertFf4j assertThatFeatureDoesNotExist(String featureName) {
-        Assert.assertFalse("Feature '" + featureName + "' must not exist", ff4j.exist(featureName));
+        Assert.assertFalse(FEATURE + featureName + "' must not exist", ff4j.exist(featureName));
         return this;
     }
     
@@ -91,7 +93,7 @@ public class AssertFf4j {
      * @return current object
      */
     public final AssertFf4j assertThatPropertyDoesNotExist(String propertyName) {
-        Assert.assertFalse("Property '" + propertyName + "' is mandatory", ff4j.getPropertiesStore().existProperty(propertyName));
+        Assert.assertFalse("Property '" + propertyName + IS_MANDATORY, ff4j.getPropertiesStore().existProperty(propertyName));
         return this;
     }
 
@@ -328,7 +330,7 @@ public class AssertFf4j {
      * @return current object
      */
     public final AssertFf4j assertThatFeatureHasFlippingStrategy(String featureName) {
-        Assert.assertNotNull("Feature '" + featureName + "' must have a FlippingStrategy but doesn't", ff4j.getFeature(featureName).getFlippingStrategy());
+        Assert.assertNotNull(FEATURE + featureName + "' must have a FlippingStrategy but doesn't", ff4j.getFeature(featureName).getFlippingStrategy());
         return this;
     }
     
@@ -340,7 +342,7 @@ public class AssertFf4j {
      * @return current object
      */
     public final AssertFf4j assertThatFeatureDoesNotHaveFlippingStrategy(String featureName) {
-        Assert.assertNull("Feature '" + featureName + "' must not have a flipping strategy", ff4j.getFeature(featureName).getFlippingStrategy());
+        Assert.assertNull(FEATURE + featureName + "' must not have a flipping strategy", ff4j.getFeature(featureName).getFlippingStrategy());
         return this;
     }
     

--- a/ff4j-test/src/main/java/org/ff4j/test/cache/AbstractCacheManagerJUnitTest.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/cache/AbstractCacheManagerJUnitTest.java
@@ -34,7 +34,8 @@ import org.junit.Test;
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
 public abstract class AbstractCacheManagerJUnitTest implements TestsFf4jConstants {
-    
+
+    public static final String DESCRIPTION = "Description";
     /** Cache Manager. */
     protected FF4JCacheManager cacheManager = getCacheManager();
     
@@ -64,7 +65,7 @@ public abstract class AbstractCacheManagerJUnitTest implements TestsFf4jConstant
     @Test
     public void testPutOK() {
         // Given
-        Feature ff = new Feature("ff", false, "Description");
+        Feature ff = new Feature("ff", false, DESCRIPTION);
         Assert.assertFalse(cacheManager.listCachedFeatureNames().contains(ff.getUid()));
         // When
         cacheManager.putFeature(ff);
@@ -80,8 +81,8 @@ public abstract class AbstractCacheManagerJUnitTest implements TestsFf4jConstant
         // Given
         Assert.assertTrue(cacheManager.listCachedFeatureNames().isEmpty());
         // When
-        cacheManager.putFeature(new Feature("ff", false, "Description"));
-        cacheManager.putFeature(new Feature("ff2", false, "Description"));
+        cacheManager.putFeature(new Feature("ff", false, DESCRIPTION));
+        cacheManager.putFeature(new Feature("ff2", false, DESCRIPTION));
         // Then
         Assert.assertEquals(2, cacheManager.listCachedFeatureNames().size());
     }
@@ -94,9 +95,9 @@ public abstract class AbstractCacheManagerJUnitTest implements TestsFf4jConstant
         // Given
         Assert.assertTrue(cacheManager.listCachedFeatureNames().isEmpty());
         // When
-        cacheManager.putFeature(new Feature("ff", false, "Description"));
-        cacheManager.putFeature(new Feature("ff", false, "Description"));
-        cacheManager.putFeature(new Feature("ff2", false, "Description"));
+        cacheManager.putFeature(new Feature("ff", false, DESCRIPTION));
+        cacheManager.putFeature(new Feature("ff", false, DESCRIPTION));
+        cacheManager.putFeature(new Feature("ff2", false, DESCRIPTION));
         // Then
         Assert.assertEquals(2, cacheManager.listCachedFeatureNames().size());
     }
@@ -107,7 +108,7 @@ public abstract class AbstractCacheManagerJUnitTest implements TestsFf4jConstant
     @Test
     public void testEvictOK() {
         // Given
-        cacheManager.putFeature(new Feature("ff", false, "Description"));
+        cacheManager.putFeature(new Feature("ff", false, DESCRIPTION));
         Assert.assertTrue(cacheManager.listCachedFeatureNames().contains("ff"));
         // When
         cacheManager.evictFeature("ff");
@@ -134,9 +135,9 @@ public abstract class AbstractCacheManagerJUnitTest implements TestsFf4jConstant
     @Test
     public void testClear() {
         // Given
-        cacheManager.putFeature(new Feature("ff", false, "Description"));
-        cacheManager.putFeature(new Feature("ff2", false, "Description"));
-        cacheManager.putFeature(new Feature("ff3", false, "Description"));
+        cacheManager.putFeature(new Feature("ff", false, DESCRIPTION));
+        cacheManager.putFeature(new Feature("ff2", false, DESCRIPTION));
+        cacheManager.putFeature(new Feature("ff3", false, DESCRIPTION));
         Assert.assertEquals(3, cacheManager.listCachedFeatureNames().size());
         // When
         cacheManager.clearFeatures();

--- a/ff4j-test/src/main/java/org/ff4j/test/propertystore/PropertyStoreTestSupport.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/propertystore/PropertyStoreTestSupport.java
@@ -45,6 +45,11 @@ import org.junit.Test;
  */
 public abstract class PropertyStoreTestSupport {
 
+    public static final String ADD_PROPERTY_O_KSIMPLE = "addPropertyOKsimple";
+    public static final String READ_OK_FIXED = "readOKFixed";
+    public static final String INVALID = "invalid";
+    public static final String UPDATE_OK = "updateOK";
+    public static final String DELETE_OK = "deleteOK";
     /** Tested Store. */
     protected PropertyStore testedStore;
 
@@ -98,11 +103,11 @@ public abstract class PropertyStoreTestSupport {
     @Test
     public void addPropertyOKsimple() {
         // Given
-        Assert.assertFalse(testedStore.existProperty("addPropertyOKsimple"));
+        Assert.assertFalse(testedStore.existProperty(ADD_PROPERTY_O_KSIMPLE));
         // When
-        testedStore.createProperty(new PropertyString("addPropertyOKsimple", "ff4j"));
+        testedStore.createProperty(new PropertyString(ADD_PROPERTY_O_KSIMPLE, "ff4j"));
         // Then
-        Assert.assertTrue(testedStore.existProperty("addPropertyOKsimple"));
+        Assert.assertTrue(testedStore.existProperty(ADD_PROPERTY_O_KSIMPLE));
     }
     
     /** TDD. */
@@ -167,13 +172,13 @@ public abstract class PropertyStoreTestSupport {
     @Test
     public void readOKFixed() {
         // Given
-        testedStore.createProperty(new PropertyLogLevel("readOKFixed", LogLevel.ERROR));
+        testedStore.createProperty(new PropertyLogLevel(READ_OK_FIXED, LogLevel.ERROR));
         // When
-        Property<?> log = testedStore.readProperty("readOKFixed");
+        Property<?> log = testedStore.readProperty(READ_OK_FIXED);
         // Then
         Assert.assertNotNull(log);
         Assert.assertNotNull(log.getName());
-        Assert.assertEquals("readOKFixed", log.getName());
+        Assert.assertEquals(READ_OK_FIXED, log.getName());
         Assert.assertEquals(LogLevel.ERROR, log.getValue());
         Assert.assertEquals("ERROR", log.asString());
         Assert.assertNotNull(log.getFixedValues());
@@ -197,9 +202,9 @@ public abstract class PropertyStoreTestSupport {
     @Test(expected = PropertyNotFoundException.class)
     public void readKOnotExist() {
         // Given
-        Assert.assertFalse(testedStore.existProperty("invalid"));
+        Assert.assertFalse(testedStore.existProperty(INVALID));
         // When
-        testedStore.readProperty("invalid");
+        testedStore.readProperty(INVALID);
     }
     
     // ------------------ update --------------------
@@ -208,9 +213,9 @@ public abstract class PropertyStoreTestSupport {
     @Test(expected = PropertyNotFoundException.class)
     public void updateKOdoesnotExist() {
         // Given
-        Assert.assertFalse(testedStore.existProperty("invalid"));
+        Assert.assertFalse(testedStore.existProperty(INVALID));
         // When
-        testedStore.updateProperty("invalid", "aa");
+        testedStore.updateProperty(INVALID, "aa");
     }
     
     /** TDD. */
@@ -256,11 +261,11 @@ public abstract class PropertyStoreTestSupport {
     @Test
     public void updateOK() {
         // Given
-        testedStore.createProperty(new PropertyLogLevel("updateOK", LogLevel.ERROR));
+        testedStore.createProperty(new PropertyLogLevel(UPDATE_OK, LogLevel.ERROR));
         // When
-        testedStore.updateProperty("updateOK", "INFO");
+        testedStore.updateProperty(UPDATE_OK, "INFO");
         // Then
-        Assert.assertEquals(LogLevel.INFO, testedStore.readProperty("updateOK").getValue());
+        Assert.assertEquals(LogLevel.INFO, testedStore.readProperty(UPDATE_OK).getValue());
     }
     
     /** TDD. */
@@ -295,21 +300,21 @@ public abstract class PropertyStoreTestSupport {
     @Test(expected = PropertyNotFoundException.class)
     public void deleteKOdoesnotexist() {
         // Given
-        Assert.assertFalse(testedStore.existProperty("invalid"));
+        Assert.assertFalse(testedStore.existProperty(INVALID));
         // When
-        testedStore.deleteProperty("invalid");
+        testedStore.deleteProperty(INVALID);
     }
     
     /** TDD. */
     @Test
     public void deleteOK() {
         // Given
-        testedStore.createProperty(new PropertyString("deleteOK", "ff4j"));
-        Assert.assertTrue(testedStore.existProperty("deleteOK"));
+        testedStore.createProperty(new PropertyString(DELETE_OK, "ff4j"));
+        Assert.assertTrue(testedStore.existProperty(DELETE_OK));
         // When
-        testedStore.deleteProperty("deleteOK");
+        testedStore.deleteProperty(DELETE_OK);
         // Then
-        Assert.assertFalse(testedStore.existProperty("deleteOK"));
+        Assert.assertFalse(testedStore.existProperty(DELETE_OK));
     }
     
     @Test

--- a/ff4j-test/src/main/java/org/ff4j/test/store/FeatureStoreTestSupport.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/store/FeatureStoreTestSupport.java
@@ -41,6 +41,11 @@ import org.junit.Test;
  */
 public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
 
+    public static final String GOLOGOLO = "GOLOGOLO";
+    public static final String ROLE_XYZ = "ROLE_XYZ";
+    public static final String PPSTRING = "ppstring";
+    public static final String DIGIT_VALUE = "digitValue";
+    public static final String REGION_IDENTIFIER = "regionIdentifier";
     /** Initialize */
     protected FF4j ff4j = null;
     
@@ -284,15 +289,15 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
     @Test(expected = FeatureAlreadyExistException.class)
     public void testAddFeatureAlreadyExis() throws Exception {
         // Given
-        assertFf4j.assertThatFeatureDoesNotExist("GOLOGOLO");
+        assertFf4j.assertThatFeatureDoesNotExist(GOLOGOLO);
         // When (first creation)
-        Feature fp = new Feature("GOLOGOLO", true, "description2");
+        Feature fp = new Feature(GOLOGOLO, true, "description2");
         testedStore.create(fp);
         // Then (first creation)
-        assertFf4j.assertThatFeatureExist("GOLOGOLO");
+        assertFf4j.assertThatFeatureExist(GOLOGOLO);
         // When (second creation)
         Set<String> rights = new HashSet<String>(Arrays.asList(new String[] {ROLE_USER}));
-        Feature fp2 = new Feature("GOLOGOLO", true, G1, "description3", rights);
+        Feature fp2 = new Feature(GOLOGOLO, true, G1, "description3", rights);
         testedStore.create(fp2);
         // Then, expected exception
     }
@@ -390,11 +395,11 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
     public void testGrantRoleToFeatureRoleDoesNotExist() throws Exception {
         // Given
         assertFf4j.assertThatFeatureExist(F1);
-        assertFf4j.assertThatFeatureHasNotRole(F1, "ROLE_XYZ");
+        assertFf4j.assertThatFeatureHasNotRole(F1, ROLE_XYZ);
         // When
-        testedStore.grantRoleOnFeature(F1, "ROLE_XYZ");
+        testedStore.grantRoleOnFeature(F1, ROLE_XYZ);
         // Then
-        assertFf4j.assertThatFeatureHasRole(F1, "ROLE_XYZ");
+        assertFf4j.assertThatFeatureHasRole(F1, ROLE_XYZ);
     }
 
     /**
@@ -1108,26 +1113,26 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
         assertFf4j.assertThatFeatureExist(F1);
         Feature myFeature = ff4j.getFeatureStore().read(F1);
         if (myFeature.getCustomProperties().isEmpty()) {
-            PropertyString p1 = new PropertyString("ppstring");
+            PropertyString p1 = new PropertyString(PPSTRING);
             p1.setValue("hello");
             myFeature.getCustomProperties().put(p1.getName(), p1);
             testedStore.update(myFeature);
         }
-        assertFf4j.assertThatFeatureHasProperty(F1, "ppstring");
+        assertFf4j.assertThatFeatureHasProperty(F1, PPSTRING);
         Assert.assertEquals("hello", 
                 ff4j.getFeatureStore().read(F1)//
-                    .getCustomProperties().get("ppstring")//
+                    .getCustomProperties().get(PPSTRING)//
                     .asString());
         // When
         myFeature = ff4j.getFeatureStore().read(F1);
-        PropertyString p1 = new PropertyString("ppstring", "goodbye");
+        PropertyString p1 = new PropertyString(PPSTRING, "goodbye");
         myFeature.getCustomProperties().put(p1.getName(), p1);
         testedStore.update(myFeature);
         
         // Then
         Assert.assertEquals("goodbye", 
                 ff4j.getFeatureStore().read(F1)//
-                    .getCustomProperties().get("ppstring")//
+                    .getCustomProperties().get(PPSTRING)//
                     .asString());
     }
     
@@ -1140,19 +1145,19 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
         // Given
         assertFf4j.assertThatFeatureExist(F1);
         Feature myFeature = ff4j.getFeatureStore().read(F1);
-        myFeature.addProperty(new PropertyInt("digitValue", 2, Util.set(0,1,2,3)));
+        myFeature.addProperty(new PropertyInt(DIGIT_VALUE, 2, Util.set(0,1,2,3)));
         ff4j.getFeatureStore().update(myFeature);
-        assertFf4j.assertThatFeatureHasProperty(F1, "digitValue");
+        assertFf4j.assertThatFeatureHasProperty(F1, DIGIT_VALUE);
         
         Set < Integer > fixValues = (Set<Integer>) ff4j
                 .getFeatureStore().read(F1)//
-                .getCustomProperties().get("digitValue")
+                .getCustomProperties().get(DIGIT_VALUE)
                 .getFixedValues();
         Assert.assertEquals(4, fixValues.size());
                 
         // When
         myFeature = ff4j.getFeatureStore().read(F1);
-        PropertyInt p1 = new PropertyInt("digitValue");
+        PropertyInt p1 = new PropertyInt(DIGIT_VALUE);
         p1.setFixedValues(Util.set(0,1,2,3,4));
         p1.setValue(4);
         myFeature.getCustomProperties().put(p1.getName(), p1);
@@ -1161,7 +1166,7 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
         // Then
         Set < Integer > fixValues2 = (Set<Integer>) ff4j
                 .getFeatureStore().read(F1) //
-                .getCustomProperties().get("digitValue")
+                .getCustomProperties().get(DIGIT_VALUE)
                 .getFixedValues();
         Assert.assertEquals(5, fixValues2.size());
     }
@@ -1175,18 +1180,18 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
      // Given
         assertFf4j.assertThatFeatureExist(F1);
         Feature myFeature = ff4j.getFeatureStore().read(F1);
-        myFeature.addProperty(new PropertyString("regionIdentifier", "AMER", Util.set("AMER","SSSS","EAST")));
+        myFeature.addProperty(new PropertyString(REGION_IDENTIFIER, "AMER", Util.set("AMER","SSSS","EAST")));
         testedStore.update(myFeature);
-        assertFf4j.assertThatFeatureHasProperty(F1, "regionIdentifier");
+        assertFf4j.assertThatFeatureHasProperty(F1, REGION_IDENTIFIER);
         Set < String > fixValues = (Set<String>) ff4j
                 .getFeatureStore().read(F1)//
-                .getCustomProperties().get("regionIdentifier")
+                .getCustomProperties().get(REGION_IDENTIFIER)
                 .getFixedValues();
         Assert.assertEquals(3, fixValues.size()); 
                 
         // When
         myFeature = ff4j.getFeatureStore().read(F1);
-        PropertyString p1 = new PropertyString("regionIdentifier");
+        PropertyString p1 = new PropertyString(REGION_IDENTIFIER);
         p1.setValue("AMER");
         p1.setFixedValues(Util.set("AMER", "SSSS"));
         myFeature.getCustomProperties().put(p1.getName(), p1);
@@ -1195,7 +1200,7 @@ public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
         // Then
         Set < Integer > fixValues2 = (Set<Integer>) ff4j
                 .getFeatureStore().read(F1)//
-                .getCustomProperties().get("regionIdentifier")
+                .getCustomProperties().get(REGION_IDENTIFIER)
                 .getFixedValues();
         Assert.assertEquals(2, fixValues2.size());
     }

--- a/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
+++ b/ff4j-utils-json/src/main/java/org/ff4j/utils/json/PropertyJsonParser.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public final class PropertyJsonParser {
 
+    public static final String FIXED_VALUES = "fixedValues";
     /** Jackson mapper. */
     private static ObjectMapper objectMapper = new ObjectMapper();
     
@@ -70,7 +71,7 @@ public final class PropertyJsonParser {
         Property < ?> ap = PropertyFactory.createProperty(propertyName, propertyType, propertyVal);
         
         // FixedValued
-        List <Object> listOfFixedValue = (List<Object>) propertyJson.get("fixedValues");
+        List <Object> listOfFixedValue = (List<Object>) propertyJson.get(FIXED_VALUES);
         if (listOfFixedValue != null) {
             for (Object v : listOfFixedValue) {
                 ap.add2FixedValueFromString(String.valueOf(v));
@@ -126,8 +127,8 @@ public final class PropertyJsonParser {
         pf.setDescription((String) fMap.get("description"));
         pf.setType((String) fMap.get("type"));
         pf.setValue((String) fMap.get("value"));
-        if (fMap.containsKey("fixedValues")) {
-            List < String > dbList = (ArrayList<String>) fMap.get("fixedValues");
+        if (fMap.containsKey(FIXED_VALUES)) {
+            List < String > dbList = (ArrayList<String>) fMap.get(FIXED_VALUES);
             if (dbList != null) {
                 for(Object item : dbList) {
                     pf.addFixedValue((String) item);

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
@@ -56,6 +56,7 @@ public class ConsoleServlet extends HttpServlet implements ConsoleConstants {
 
     /** Logger for this class. */
     public static final Logger LOGGER = LoggerFactory.getLogger(ConsoleServlet.class);
+    public static final String ERROR = "error";
 
     /** instance of ff4j. */
     private FF4j ff4j = null;
@@ -210,7 +211,7 @@ public class ConsoleServlet extends HttpServlet implements ConsoleConstants {
 
         } catch (Exception e) {
             // Any Error is trapped and display in the console
-            messagetype = "error";
+            messagetype = ERROR;
             message = e.getMessage();
             LOGGER.error("An error occured ", e);
         }
@@ -239,7 +240,7 @@ public class ConsoleServlet extends HttpServlet implements ConsoleConstants {
                             importFile(getFf4j(), item.getInputStream());
                             message = "The file <b>" + filename + "</b> has been successfully imported";
                         } else {
-                            messagetype = "error";
+                            messagetype = ERROR;
                             message = "Invalid FILE, must be CSV, XML or PROPERTIES files";
                         }
                     }
@@ -284,18 +285,18 @@ public class ConsoleServlet extends HttpServlet implements ConsoleConstants {
                         }
                     } else {
                         LOGGER.error("Invalid POST OPERATION" + operation);
-                        messagetype = "error";
+                        messagetype = ERROR;
                         message = "Invalid REQUEST";
                     }
                 } else {
                     LOGGER.error("No ID provided" + operation);
-                    messagetype = "error";
+                    messagetype = ERROR;
                     message = "Invalid UID";
                 }
             }
 
         } catch (Exception e) {
-            messagetype = "error";
+            messagetype = ERROR;
             message = e.getMessage();
             LOGGER.error("An error occured ", e);
         }

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/PropertyStoreHttp.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/PropertyStoreHttp.java
@@ -56,6 +56,7 @@ import com.sun.jersey.core.util.Base64;
  */
 public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebConstants {
 
+    public static final String OCCURED = " occured.";
     /** Jersey Client. */
     protected Client client = null;
 
@@ -171,7 +172,7 @@ public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebC
         
         // Check response code CREATED or raised error
         if (Status.CREATED.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot create properties, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot create properties, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -195,7 +196,7 @@ public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebC
             throw new PropertyNotFoundException(name);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new PropertyAccessException("Cannot delete property, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new PropertyAccessException("Cannot delete property, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -203,7 +204,7 @@ public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebC
     public Map<String, Property<?>> readAllProperties() {
         ClientResponse cRes = getStore().get(ClientResponse.class);
         if (Status.OK.getStatusCode() != cRes.getStatus()) {
-            throw new PropertyAccessException("Cannot read properties, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new PropertyAccessException("Cannot read properties, an HTTP error " + cRes.getStatus() + OCCURED);
         }
         String resEntity = cRes.getEntity(String.class);
         Property<?>[] pArray = PropertyJsonParser.parsePropertyArray(resEntity);

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/PropertyStoreHttp.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/PropertyStoreHttp.java
@@ -57,6 +57,7 @@ import io.swagger.jaxrs.json.JacksonJsonProvider;
  */
 public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebConstants {
 
+    public static final String OCCURED = " occured.";
     /** Jersey Client. */
     protected Client client = null;
 
@@ -168,7 +169,7 @@ public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebC
         
         // Check response code CREATED or raised error
         if (Status.CREATED.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot create properties, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot create properties, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -193,7 +194,7 @@ public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebC
             throw new PropertyNotFoundException(name);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new PropertyAccessException("Cannot delete property, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new PropertyAccessException("Cannot delete property, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -201,7 +202,7 @@ public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebC
     public Map<String, Property<?>> readAllProperties() {
         Response cRes = getStore().request(MediaType.APPLICATION_JSON_TYPE).get();
         if (Status.OK.getStatusCode() != cRes.getStatus()) {
-            throw new PropertyAccessException("Cannot read properties, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new PropertyAccessException("Cannot read properties, an HTTP error " + cRes.getStatus() + OCCURED);
         }
         String resEntity = cRes.readEntity(String.class);
         Property<?>[] pArray = PropertyJsonParser.parsePropertyArray(resEntity);


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava