### PR TITLE
Multiple code improvements - squid:S1444, squid:S1149, squid:S1854, squid:S2293

### DIFF
--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/mapper/Neo4jMapper.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/mapper/Neo4jMapper.java
@@ -126,7 +126,7 @@ public class Neo4jMapper implements FF4jNeo4jConstants {
         }
         if (nodeProperties.containsKey(NODEPROPERTY_ATT_FIXEDVALUES)) {
             String[] listOfValues = (String[]) nodeProperty.getProperty(NODEPROPERTY_ATT_FIXEDVALUES);
-            Set < String > fixedValues = new HashSet<String>(Arrays.asList(listOfValues));
+            Set < String > fixedValues = new HashSet<>(Arrays.asList(listOfValues));
             return PropertyFactory.createProperty(propertyName, propertyType, propertyValue ,propertyDescription, fixedValues);
         } else {
             Property<?> ap = PropertyFactory.createProperty(propertyName, propertyType, propertyValue);

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/PropertyStoreNeo4j.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/PropertyStoreNeo4j.java
@@ -114,7 +114,7 @@ public class PropertyStoreNeo4j extends AbstractPropertyStore implements FF4jNeo
     /** {@inheritDoc} */
     public Property<?> readProperty(String name) {
         assertPropertyName(name);
-        Property<?> pro = null;
+        Property<?> pro;
         Transaction tx = graphDb.beginTx();
         Map<String, Object> queryParameters = new HashMap<>();
         queryParameters.put("name", name);

--- a/ff4j-store-redis/src/main/java/org/ff4j/store/EventRepositoryRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/store/EventRepositoryRedis.java
@@ -36,7 +36,7 @@ import org.ff4j.redis.RedisConnection;
 public class EventRepositoryRedis extends AbstractEventRepository {
 
 	/** prefix of keys. */
-    public static String KEY_PROPERTY = "FF4J_EVENT_";
+    public static final String KEY_PROPERTY = "FF4J_EVENT_";
     
     /** default ttl. */
     private static int DEFAULT_TTL = 900000000;

--- a/ff4j-store-redis/src/main/java/org/ff4j/store/PropertyStoreRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/store/PropertyStoreRedis.java
@@ -42,7 +42,7 @@ import redis.clients.jedis.Jedis;
 public class PropertyStoreRedis extends AbstractPropertyStore {
 
     /** prefix of keys. */
-    public static String KEY_PROPERTY = "FF4J_PROPERTY_";
+    public static final String KEY_PROPERTY = "FF4J_PROPERTY_";
     
     /** default ttl. */
     private static int DEFAULT_TTL = 900000000;

--- a/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
+++ b/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
@@ -190,7 +190,7 @@ public final class FF4jDroolsService implements Serializable {
         InputStream rin = null;
         try {
             rin = ClassLoader.getSystemResourceAsStream(resourceName);
-            StringBuffer out = new StringBuffer();
+            StringBuilder out = new StringBuilder();
             byte[] b = new byte[4096];
             int n = 0;
             while (n != -1) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1444 - "public static" fields should be constant.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S1854 - Dead stores should be removed.
squid:S2293 - The diamond operator ("<>") should be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
George Kankava