### PR TITLE
squid:S1214 - Constants should not be defined in interfaces

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4JPlaceHolderBeanDefinitionParser.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4JPlaceHolderBeanDefinitionParser.java
@@ -34,12 +34,14 @@ import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.w3c.dom.Element;
 
+import static org.ff4j.spring.namespace.FF4jNameSpaceConstants.*;
+
 /**
  * Custom and simple implementation of a {@link BeanDefinitionParser} to create and {@link FF4jPropertiesPlaceHolderConfigurer}.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FF4JPlaceHolderBeanDefinitionParser implements BeanDefinitionParser, FF4jNameSpaceConstants {
+public class FF4JPlaceHolderBeanDefinitionParser implements BeanDefinitionParser {
 
     /** logger for class. */
     private static Log logger = LogFactory.getLog(FF4jBeanDefinitionParser.class);

--- a/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jBeanDefinitionParser.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jBeanDefinitionParser.java
@@ -32,12 +32,14 @@ import org.springframework.beans.factory.xml.AbstractSimpleBeanDefinitionParser;
 import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
+import static org.ff4j.spring.namespace.FF4jNameSpaceConstants.*;
+
 /**
  * Parser for tag <ff4j:ff4j>
  *
  * @author Lunven Cedrick
  */
-public final class FF4jBeanDefinitionParser extends AbstractSimpleBeanDefinitionParser implements FF4jNameSpaceConstants {
+public final class FF4jBeanDefinitionParser extends AbstractSimpleBeanDefinitionParser {
 
     /** logger for class. **/
     private static Log logger = LogFactory.getLog(FF4jBeanDefinitionParser.class);

--- a/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jNameSpaceConstants.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jNameSpaceConstants.java
@@ -26,44 +26,44 @@ package org.ff4j.spring.namespace;
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public interface FF4jNameSpaceConstants {
+public class FF4jNameSpaceConstants {
 
     /** Namespace Prefix for tgas. **/
-   String PREFIX = "ff4j:";
+   public static final String PREFIX = "ff4j:";
 
     /** XML Tag. **/
-   String TAG_PLACEHOLDER = "property-placeholder";
+   public static final String TAG_PLACEHOLDER = "property-placeholder";
 
     /** XML Tag. **/
-   String TAG_FF4J = "ff4j";
+   public static final String TAG_FF4J = "ff4j";
    
    /** XML Attribute. **/
-   String ATT_FF4J_ID = "id";
+   public static final String ATT_FF4J_ID = "id";
    
    /** XML Attribute. **/
-   String ATT_FF4J_AUTOCREATE = "autocreate";
+   public static final String ATT_FF4J_AUTOCREATE = "autocreate";
    
    /** XML Attribute. **/
-   String ATT_FF4J_FILENAME = "fileName";
+   public static final String ATT_FF4J_FILENAME = "fileName";
    
    /** XML Attribute. **/
-   String ATT_FF4J_AUTH_MANAGER = "authManager";
+   public static final String ATT_FF4J_AUTH_MANAGER = "authManager";
    
    /** XML Attribute. **/
-   String ATT_FF4J_STORE_PROPERTY = "storeProperty";
+   public static final String ATT_FF4J_STORE_PROPERTY = "storeProperty";
    
    /** XML Attribute. **/
-   String ATT_FF4J_STORE_FEATURE = "storeFeature";
+   public static final String ATT_FF4J_STORE_FEATURE = "storeFeature";
    
    /** XML Attribute. **/
-   String ATT_FF4J_AUDIT_REPOSITORY = "auditRepository";
+   public static final String ATT_FF4J_AUDIT_REPOSITORY = "auditRepository";
    
    /** Bean id. */
-   String BEANID_PLACEHOLDER_CONF = "ff4j.placeholderconfigurer";
+   public static final String BEANID_PLACEHOLDER_CONF = "ff4j.placeholderconfigurer";
    
    /** Bean id. */
-   String BEANID_PLACEHOLDER = "ff4j.placeholder";
+   public static final String BEANID_PLACEHOLDER = "ff4j.placeholder";
    
-   
+   private FF4jNameSpaceConstants() {}
    
 }

--- a/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jNameSpaceHandler.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/namespace/FF4jNameSpaceHandler.java
@@ -25,12 +25,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
 
+import static org.ff4j.spring.namespace.FF4jNameSpaceConstants.*;
+
 /**
  * Use Spring NameSpace to simplify settings.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FF4jNameSpaceHandler extends NamespaceHandlerSupport implements FF4jNameSpaceConstants {
+public class FF4jNameSpaceHandler extends NamespaceHandlerSupport {
 
     /** Logger statique pour la classe. **/
     private static Log logger = LogFactory.getLog(FF4jNameSpaceHandler.class);

--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -45,6 +45,7 @@ import org.ff4j.property.store.PropertyStore;
 import org.ff4j.security.AuthorizationsManager;
 import org.ff4j.store.InMemoryFeatureStore;
 
+import static org.ff4j.audit.EventConstants.*;
 /**
  * Principal class stands as public api to work with FF4J.
  *
@@ -69,7 +70,7 @@ import org.ff4j.store.InMemoryFeatureStore;
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public class FF4j implements EventConstants {
+public class FF4j {
 
     /** Do not through {@link FeatureNotFoundException} exception and but feature is required. */
     private boolean autocreate = false;

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventBuilder.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventBuilder.java
@@ -22,7 +22,9 @@ package org.ff4j.audit;
 
 import org.ff4j.FF4j;
 
-public class EventBuilder implements EventConstants {
+import static org.ff4j.audit.EventConstants.*;
+
+public class EventBuilder {
     
     /** API Configuration. */
     private Event event;

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventConstants.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventConstants.java
@@ -25,33 +25,40 @@ package org.ff4j.audit;
  * 
  * @author clunven
  */
-public interface EventConstants {
+public class EventConstants {
 	
 	/** ACTIONS. */
-	String ACTION_CONNECT 		= "connect";
-	String ACTION_DISCONNECT 	= "disconnect";
-	String ACTION_TOGGLE_ON 	= "toggle-on";
-	String ACTION_TOGGLE_OFF 	= "toggle-off";
-	String ACTION_CREATE 		= "create";
-	String ACTION_DELETE 		= "delete";
-	String ACTION_UPDATE 		= "update";
-	String ACTION_CLEAR 		= "clear";
-	String ACTION_CHECK_OK      = "checkOn";
-	String ACTION_CHECK_OFF     = "checkOff";
+	public static final String ACTION_CONNECT 		= "connect";
+	public static final String ACTION_DISCONNECT 	= "disconnect";
+	public static final String ACTION_TOGGLE_ON 	= "toggle-on";
+	public static final String ACTION_TOGGLE_OFF 	= "toggle-off";
+	public static final String ACTION_CREATE 		= "create";
+	public static final String ACTION_DELETE 		= "delete";
+	public static final String ACTION_UPDATE 		= "update";
+	public static final String ACTION_CLEAR 		= "clear";
+	public static final String ACTION_CHECK_OK      = "checkOn";
+	public static final String ACTION_CHECK_OFF     = "checkOff";
     
 	/** TARGETS. */
-	String TARGET_FEATURE 	= "feature";
-	String TARGET_GROUP 	= "group";
-	String TARGET_PROPERTY 	= "property";
-	String TARGET_USER 		= "user";
-	String TARGET_FSTORE 	= "featureStore";
-	String TARGET_PSTORE 	= "propertyStore";
+	public static final String TARGET_FEATURE 	= "feature";
+	public static final String TARGET_GROUP 	= "group";
+	public static final String TARGET_PROPERTY 	= "property";
+	public static final String TARGET_USER 		= "user";
+	public static final String TARGET_FSTORE 	= "featureStore";
+	public static final String TARGET_PSTORE 	= "propertyStore";
 	
 	/** SOURCES. */
-	String SOURCE_JAVA     = "JAVA_API";
-	String SOURCE_WEB      = "EMBEDDED_SERVLET";
-	String SOURCE_WEBAPI   = "WEB_API";
-	String SOURCE_SSH      = "SSH";
-    
-    
+	public static final String SOURCE_JAVA     = "JAVA_API";
+	public static final String SOURCE_WEB      = "EMBEDDED_SERVLET";
+	public static final String SOURCE_WEBAPI   = "WEB_API";
+	public static final String SOURCE_SSH      = "SSH";
+
+	/** total hit count. */
+	public static final String TITLE_PIE_HITCOUNT = "Total Hit Counts";
+
+	/** distribution. */
+	public static final String TITLE_BARCHAR_HIT = "HitCounts Distribution";
+
+
+	private EventConstants() {}
 }

--- a/ff4j-core/src/main/java/org/ff4j/audit/proxy/FeatureStoreAuditProxy.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/proxy/FeatureStoreAuditProxy.java
@@ -30,12 +30,14 @@ import org.ff4j.audit.EventPublisher;
 import org.ff4j.core.Feature;
 import org.ff4j.core.FeatureStore;
 
+import static org.ff4j.audit.EventConstants.*;
+
 /**
  * Proxy to publish operation to audit.
  *
  * @author Cedrick Lunven (@clunven)
  */
-public class FeatureStoreAuditProxy implements FeatureStore, EventConstants {
+public class FeatureStoreAuditProxy implements FeatureStore {
 
     /** Current FeatureStore. */
     private FeatureStore target = null;

--- a/ff4j-core/src/main/java/org/ff4j/audit/proxy/PropertyStoreAuditProxy.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/proxy/PropertyStoreAuditProxy.java
@@ -25,17 +25,18 @@ import java.util.Set;
 
 import org.ff4j.FF4j;
 import org.ff4j.audit.EventBuilder;
-import org.ff4j.audit.EventConstants;
 import org.ff4j.audit.EventPublisher;
 import org.ff4j.property.Property;
 import org.ff4j.property.store.PropertyStore;
+
+import static org.ff4j.audit.EventConstants.*;
 
 /**
  * Implementation of audit on top of store.
  *
  * @author Cedrick Lunven (@clunven)
  */
-public class PropertyStoreAuditProxy implements PropertyStore, EventConstants {
+public class PropertyStoreAuditProxy implements PropertyStore {
 
     /** Current FeatureStore. */
     private PropertyStore target = null;

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/AbstractEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/AbstractEventRepository.java
@@ -33,6 +33,7 @@ import org.ff4j.audit.graph.BarChart;
 import org.ff4j.audit.graph.PieChart;
 import org.ff4j.audit.graph.PieSector;
 
+import static org.ff4j.audit.EventConstants.*;
 
 /**
  * Superclass implementing the custom serialization.

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/EventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/EventRepository.java
@@ -32,14 +32,8 @@ import org.ff4j.audit.graph.PieChart;
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public interface EventRepository extends EventConstants {
+public interface EventRepository {
 
-    /** total hit count. */
-    String TITLE_PIE_HITCOUNT = "Total Hit Counts";
-    
-    /** distribution. */
-    String TITLE_BARCHAR_HIT = "HitCounts Distribution";
-    
     /**
      * Save event into store synchronously.
      * 

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/InMemoryEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/InMemoryEventRepository.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.ff4j.audit.Event;
-import org.ff4j.audit.EventConstants;
 import org.ff4j.audit.graph.BarChart;
 import org.ff4j.audit.graph.BarSeries;
 import org.ff4j.audit.graph.MutableInt;
@@ -40,12 +39,14 @@ import org.ff4j.audit.graph.PieChart;
 import org.ff4j.audit.graph.PieSector;
 import org.ff4j.utils.Util;
 
+import static org.ff4j.audit.EventConstants.*;
+
 /**
  * Implementation of in memory {@link EventRepository} with limited events.
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public class InMemoryEventRepository extends AbstractEventRepository implements EventConstants {
+public class InMemoryEventRepository extends AbstractEventRepository {
     
     /** default retention. */
     private static final int DEFAULT_QUEUE_CAPACITY = 100000;

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
@@ -38,15 +38,17 @@ import org.ff4j.audit.graph.PieChart;
 import org.ff4j.audit.graph.PieSector;
 import org.ff4j.exception.AuditAccessException;
 import org.ff4j.exception.FeatureAccessException;
-import org.ff4j.store.JdbcStoreConstants;
 import org.ff4j.utils.Util;
+
+import static org.ff4j.store.JdbcStoreConstants.*;
+import static org.ff4j.audit.EventConstants.*;
 
 /**
  * Implementation of in memory {@link EventRepository} with limited events.
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public class JdbcEventRepository extends AbstractEventRepository implements JdbcStoreConstants {
+public class JdbcEventRepository extends AbstractEventRepository {
 
     public static final String CANNOT_BUILD_PIE_CHART_FROM_REPOSITORY = "Cannot build PieChart from repository, ";
     /** Access to storage. */

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyMapper.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyMapper.java
@@ -30,14 +30,15 @@ import java.util.Set;
 import org.ff4j.property.Property;
 import org.ff4j.property.PropertyString;
 import org.ff4j.property.util.PropertyFactory;
-import org.ff4j.store.JdbcStoreConstants;
+
+import static org.ff4j.store.JdbcStoreConstants.*;
 
 /**
  * Convert resultset into {@link PropertyString}.
  *
  * @author Cedrick Lunven (@clunven)
  */
-public class JdbcPropertyMapper implements JdbcStoreConstants {
+public class JdbcPropertyMapper {
     
     /**
      * Expect to convert a JDBC Result to Property.

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -20,9 +20,9 @@ import org.ff4j.exception.PropertyAccessException;
 import org.ff4j.exception.PropertyAlreadyExistException;
 import org.ff4j.exception.PropertyNotFoundException;
 import org.ff4j.property.Property;
-import org.ff4j.store.JdbcStoreConstants;
 import org.ff4j.utils.Util;
 
+import static org.ff4j.store.JdbcStoreConstants.*;
 /*
  * #%L
  * ff4j-core
@@ -48,7 +48,7 @@ import org.ff4j.utils.Util;
  *
  * @author Cedrick Lunven (@clunven)
  */
-public class JdbcPropertyStore extends AbstractPropertyStore implements JdbcStoreConstants {
+public class JdbcPropertyStore extends AbstractPropertyStore {
 
     /** Access to storage. */
     private DataSource dataSource;

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureMapper.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureMapper.java
@@ -28,12 +28,14 @@ import java.util.Map;
 
 import org.ff4j.core.Feature;
 
+import static org.ff4j.store.JdbcStoreConstants.*;
+
 /**
  * Map resultset into {@link Feature}
  *
  * @author Cedrick Lunven (@clunven)
  */
-public class JdbcFeatureMapper implements JdbcStoreConstants {
+public class JdbcFeatureMapper {
     
     /**
      * Map feature result to bean.

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -52,12 +52,14 @@ import org.ff4j.utils.JdbcUtils;
 import org.ff4j.utils.MappingUtil;
 import org.ff4j.utils.Util;
 
+import static org.ff4j.store.JdbcStoreConstants.*;
+
 /**
  * Implementation of {@link FeatureStore} to work with RDBMS through JDBC.
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public class JdbcFeatureStore extends AbstractFeatureStore implements  JdbcStoreConstants {
+public class JdbcFeatureStore extends AbstractFeatureStore {
 
     public static final String CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE = "Cannot check feature existence, error related to database";
     public static final String CANNOT_UPDATE_FEATURES_DATABASE_SQL_ERROR = "Cannot update features database, SQL ERROR";

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcStoreConstants.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcStoreConstants.java
@@ -18,171 +18,171 @@ import org.ff4j.audit.EventConstants;
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public interface JdbcStoreConstants {
+public class JdbcStoreConstants {
 
     /** sql query expression */
-    String SQLQUERY_ALLFEATURES = "SELECT FEAT_UID,ENABLE,DESCRIPTION,STRATEGY,EXPRESSION,GROUPNAME FROM FF4J_FEATURES";
+    public static final String SQLQUERY_ALLFEATURES = "SELECT FEAT_UID,ENABLE,DESCRIPTION,STRATEGY,EXPRESSION,GROUPNAME FROM FF4J_FEATURES";
 
     /** sql query expression */
-    String SQLQUERY_ALLGROUPS = "SELECT DISTINCT(GROUPNAME) FROM FF4J_FEATURES";
+    public static final String SQLQUERY_ALLGROUPS = "SELECT DISTINCT(GROUPNAME) FROM FF4J_FEATURES";
 
     /** sql query expression */
-    String SQLQUERY_GET_FEATURE_GROUP = "SELECT FEAT_UID,ENABLE,DESCRIPTION,STRATEGY,EXPRESSION,GROUPNAME FROM FF4J_FEATURES WHERE GROUPNAME = ?";
+    public static final String SQLQUERY_GET_FEATURE_GROUP = "SELECT FEAT_UID,ENABLE,DESCRIPTION,STRATEGY,EXPRESSION,GROUPNAME FROM FF4J_FEATURES WHERE GROUPNAME = ?";
 
     /** sql query expression */
-    String SQL_GETFEATUREBYID = "SELECT FEAT_UID,ENABLE,DESCRIPTION,STRATEGY,EXPRESSION,GROUPNAME FROM FF4J_FEATURES WHERE FEAT_UID = ?";
+    public static final String SQL_GETFEATUREBYID = "SELECT FEAT_UID,ENABLE,DESCRIPTION,STRATEGY,EXPRESSION,GROUPNAME FROM FF4J_FEATURES WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_EXIST = "SELECT COUNT(FEAT_UID) FROM FF4J_FEATURES WHERE FEAT_UID = ?";
+    public static final String SQL_EXIST = "SELECT COUNT(FEAT_UID) FROM FF4J_FEATURES WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_DISABLE = "UPDATE FF4J_FEATURES SET ENABLE = 0 WHERE FEAT_UID = ?";
+    public static final String SQL_DISABLE = "UPDATE FF4J_FEATURES SET ENABLE = 0 WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_ADD_TO_GROUP = "UPDATE FF4J_FEATURES SET GROUPNAME = ? WHERE FEAT_UID = ?";
+    public static final String SQL_ADD_TO_GROUP = "UPDATE FF4J_FEATURES SET GROUPNAME = ? WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_REMOVE_FROM_GROUP = "UPDATE FF4J_FEATURES SET GROUPNAME = NULL WHERE FEAT_UID = ?";
+    public static final String SQL_REMOVE_FROM_GROUP = "UPDATE FF4J_FEATURES SET GROUPNAME = NULL WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_ENABLE = "UPDATE FF4J_FEATURES SET ENABLE = 1 WHERE FEAT_UID = ?";
+    public static final String SQL_ENABLE = "UPDATE FF4J_FEATURES SET ENABLE = 1 WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_ENABLE_GROUP = "UPDATE FF4J_FEATURES SET ENABLE = 1 WHERE GROUPNAME = ?";
+    public static final String SQL_ENABLE_GROUP = "UPDATE FF4J_FEATURES SET ENABLE = 1 WHERE GROUPNAME = ?";
 
     /** sql query expression */
-    String SQL_DISABLE_GROUP = "UPDATE FF4J_FEATURES SET ENABLE = 0 WHERE GROUPNAME = ?";
+    public static final String SQL_DISABLE_GROUP = "UPDATE FF4J_FEATURES SET ENABLE = 0 WHERE GROUPNAME = ?";
 
     /** sql query expression */
-    String SQL_EXIST_GROUP = "SELECT COUNT(*) FROM FF4J_FEATURES WHERE GROUPNAME = ?";
+    public static final String SQL_EXIST_GROUP = "SELECT COUNT(*) FROM FF4J_FEATURES WHERE GROUPNAME = ?";
 
     /** sql query expression */
-    String SQL_CREATE = "INSERT INTO FF4J_FEATURES(FEAT_UID, ENABLE, DESCRIPTION, STRATEGY,EXPRESSION, GROUPNAME) VALUES(?, ?, ?, ?, ?, ?)";
+    public static final String SQL_CREATE = "INSERT INTO FF4J_FEATURES(FEAT_UID, ENABLE, DESCRIPTION, STRATEGY,EXPRESSION, GROUPNAME) VALUES(?, ?, ?, ?, ?, ?)";
 
     /** sql query expression */
-    String SQL_DELETE = "DELETE FROM FF4J_FEATURES WHERE FEAT_UID = ?";
+    public static final String SQL_DELETE = "DELETE FROM FF4J_FEATURES WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_UPDATE = "UPDATE FF4J_FEATURES SET ENABLE=?,DESCRIPTION=?,STRATEGY=?,EXPRESSION=?,GROUPNAME=? WHERE FEAT_UID = ?";
+    public static final String SQL_UPDATE = "UPDATE FF4J_FEATURES SET ENABLE=?,DESCRIPTION=?,STRATEGY=?,EXPRESSION=?,GROUPNAME=? WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_ADD_ROLE = "INSERT INTO FF4J_ROLES(FEAT_UID, ROLE_NAME) VALUES (?,?)";
+    public static final String SQL_ADD_ROLE = "INSERT INTO FF4J_ROLES(FEAT_UID, ROLE_NAME) VALUES (?,?)";
     
     /** sql query expression */
-    String SQL_DELETE_ROLES = "DELETE FROM FF4J_ROLES WHERE FEAT_UID = ?";
+    public static final String SQL_DELETE_ROLES = "DELETE FROM FF4J_ROLES WHERE FEAT_UID = ?";
 
     /** sql query expression */
-    String SQL_DELETE_ROLE = "DELETE FROM FF4J_ROLES WHERE FEAT_UID = ? AND ROLE_NAME = ?";
+    public static final String SQL_DELETE_ROLE = "DELETE FROM FF4J_ROLES WHERE FEAT_UID = ? AND ROLE_NAME = ?";
 
     /** sql query expression */
-    String SQL_GET_ROLES = "SELECT ROLE_NAME FROM FF4J_ROLES WHERE FEAT_UID = ?";
+    public static final String SQL_GET_ROLES = "SELECT ROLE_NAME FROM FF4J_ROLES WHERE FEAT_UID = ?";
     
     /** sql query expression */
-    String SQL_GET_ALLROLES = "SELECT FEAT_UID,ROLE_NAME FROM FF4J_ROLES";
+    public static final String SQL_GET_ALLROLES = "SELECT FEAT_UID,ROLE_NAME FROM FF4J_ROLES";
    
     // ------- Properties -------------
     
     /** sql query expression */
-    String SQL_GETREFPROPERTIESBYID = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,DESCRIPTION,FIXEDVALUES,FEAT_UID "
+    public static final String SQL_GETREFPROPERTIESBYID = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,DESCRIPTION,FIXEDVALUES,FEAT_UID "
             + "FROM FF4J_CUSTOM_PROPERTIES "
             + "WHERE FEAT_UID = ?";
     
     /** sql query expression */
-    String SQL_GET_CUSTOMPROPERTY_BYID = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,FIXEDVALUES,FEAT_UID "
+    public static final String SQL_GET_CUSTOMPROPERTY_BYID = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,FIXEDVALUES,FEAT_UID "
             + "FROM FF4J_CUSTOM_PROPERTIES "
             + "WHERE PROPERTY_ID = ? AND FEAT_UID = ?";
     
     /** sql query expression */
-    String SQL_DELETE_CUSTOMPROPERTY = "DELETE FROM FF4J_CUSTOM_PROPERTIES WHERE PROPERTY_ID = ? AND FEAT_UID = ?";
+    public static final String SQL_DELETE_CUSTOMPROPERTY = "DELETE FROM FF4J_CUSTOM_PROPERTIES WHERE PROPERTY_ID = ? AND FEAT_UID = ?";
     
     /** sql query expression */
-    String SQL_DELETE_CUSTOMPROPERTIES = "DELETE FROM FF4J_CUSTOM_PROPERTIES WHERE FEAT_UID = ?";
+    public static final String SQL_DELETE_CUSTOMPROPERTIES = "DELETE FROM FF4J_CUSTOM_PROPERTIES WHERE FEAT_UID = ?";
     
     /** sql query expression */
-    String SQL_DELETE_ALL_CUSTOMPROPERTIES = "DELETE FROM FF4J_CUSTOM_PROPERTIES";
+    public static final String SQL_DELETE_ALL_CUSTOMPROPERTIES = "DELETE FROM FF4J_CUSTOM_PROPERTIES";
     
     /** sql query expression */
-    String SQL_DELETE_ALL_ROLES = "DELETE FROM FF4J_ROLES";
+    public static final String SQL_DELETE_ALL_ROLES = "DELETE FROM FF4J_ROLES";
     
     /** sql query expression */
-    String SQL_DELETE_ALL_FEATURES = "DELETE FROM FF4J_FEATURES";
+    public static final String SQL_DELETE_ALL_FEATURES = "DELETE FROM FF4J_FEATURES";
     
     /** sql query expression */
-    String SQL_CREATE_CUSTOMPROPERTY = 
+    public static final String SQL_CREATE_CUSTOMPROPERTY =
             "INSERT INTO FF4J_CUSTOM_PROPERTIES (" + 
             "PROPERTY_ID, CLAZZ, CURRENTVALUE, DESCRIPTION, FIXEDVALUES, FEAT_UID) " + 
             "VALUES(?, ?, ?, ?, ?, ?)";
     
     /** Create property. */
-    String SQL_PROPERTY_CREATE = "INSERT INTO FF4J_PROPERTIES(PROPERTY_ID, CLAZZ, CURRENTVALUE, DESCRIPTION, FIXEDVALUES) VALUES(?, ?, ?, ?, ?)";
+    public static final String SQL_PROPERTY_CREATE = "INSERT INTO FF4J_PROPERTIES(PROPERTY_ID, CLAZZ, CURRENTVALUE, DESCRIPTION, FIXEDVALUES) VALUES(?, ?, ?, ?, ?)";
     
     /** Delete property. */
-    String SQL_PROPERTY_DELETE = "DELETE FROM FF4J_PROPERTIES WHERE PROPERTY_ID = ?";
+    public static final String SQL_PROPERTY_DELETE = "DELETE FROM FF4J_PROPERTIES WHERE PROPERTY_ID = ?";
     
     /** Delete property. */
-    String SQL_PROPERTY_DELETE_ALL = "DELETE FROM FF4J_PROPERTIES";
+    public static final String SQL_PROPERTY_DELETE_ALL = "DELETE FROM FF4J_PROPERTIES";
     
     /** Test if property exist. */
-    String SQL_PROPERTY_EXIST = "SELECT COUNT(*) FROM FF4J_PROPERTIES WHERE PROPERTY_ID = ?";
+    public static final String SQL_PROPERTY_EXIST = "SELECT COUNT(*) FROM FF4J_PROPERTIES WHERE PROPERTY_ID = ?";
     
     /** Test if property exist. */
-    String SQL_PROPERTY_READ = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,DESCRIPTION,FIXEDVALUES FROM FF4J_PROPERTIES WHERE PROPERTY_ID = ?";
+    public static final String SQL_PROPERTY_READ = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,DESCRIPTION,FIXEDVALUES FROM FF4J_PROPERTIES WHERE PROPERTY_ID = ?";
     
     /** sql query expression */
-    String SQL_PROPERTY_UPDATE = "UPDATE FF4J_PROPERTIES SET CURRENTVALUE = ? WHERE PROPERTY_ID = ?";
+    public static final String SQL_PROPERTY_UPDATE = "UPDATE FF4J_PROPERTIES SET CURRENTVALUE = ? WHERE PROPERTY_ID = ?";
 
     /** sql query expression */
-    String SQL_PROPERTY_READALL = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,DESCRIPTION,FIXEDVALUES FROM FF4J_PROPERTIES";
+    public static final String SQL_PROPERTY_READALL = "SELECT PROPERTY_ID,CLAZZ,CURRENTVALUE,DESCRIPTION,FIXEDVALUES FROM FF4J_PROPERTIES";
     
     /** sql query expression */
-    String SQL_PROPERTY_READNAMES = "SELECT PROPERTY_ID FROM FF4J_PROPERTIES";
+    public static final String SQL_PROPERTY_READNAMES = "SELECT PROPERTY_ID FROM FF4J_PROPERTIES";
     
     
     // ------- AUDIT -------------
-    
-    String TABLE_AUDIT = "FF4J_AUDIT";
-    
-    /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_UUID = "EVT_UUID";
+
+    public static final String TABLE_AUDIT = "FF4J_AUDIT";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_TIME = "EVT_TIME";
+    public static final String COL_EVENT_UUID = "EVT_UUID";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_TYPE = "EVT_TYPE";
+    public static final String COL_EVENT_TIME = "EVT_TIME";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_NAME = "EVT_NAME";
+    public static final String COL_EVENT_TYPE = "EVT_TYPE";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_ACTION = "EVT_ACTION";
+    public static final String COL_EVENT_NAME = "EVT_NAME";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_HOSTNAME = "EVT_HOSTNAME";
+    public static final String COL_EVENT_ACTION = "EVT_ACTION";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_SOURCE = "EVT_SOURCE";
+    public static final String COL_EVENT_HOSTNAME = "EVT_HOSTNAME";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_DURATION = "EVT_DURATION";
+    public static final String COL_EVENT_SOURCE = "EVT_SOURCE";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_USER = "EVT_USER";
+    public static final String COL_EVENT_DURATION = "EVT_DURATION";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_VALUE = "EVT_VALUE";
+    public static final String COL_EVENT_USER = "EVT_USER";
     
     /** sql column name for table FF4J_AUDIT. */
-    String COL_EVENT_KEYS = "EVT_KEYS";
+    public static final String COL_EVENT_VALUE = "EVT_VALUE";
+    
+    /** sql column name for table FF4J_AUDIT. */
+    public static final String COL_EVENT_KEYS = "EVT_KEYS";
      
     /** Creation. */
-    String SQL_AUDIT_COUNT = "SELECT COUNT(*) FROM " + TABLE_AUDIT;
+    public static final String SQL_AUDIT_COUNT = "SELECT COUNT(*) FROM " + TABLE_AUDIT;
 
     /** Creation. */
-    String SQL_AUDIT_LISTFEATURES = "SELECT DISTINCT " + COL_EVENT_NAME + " FROM " + TABLE_AUDIT + " WHERE " + COL_EVENT_TYPE + " LIKE '" + EventConstants.TARGET_FEATURE + "'";
+    public static final String SQL_AUDIT_LISTFEATURES = "SELECT DISTINCT " + COL_EVENT_NAME + " FROM " + TABLE_AUDIT + " WHERE " + COL_EVENT_TYPE + " LIKE '" + EventConstants.TARGET_FEATURE + "'";
 
     /** Get all information for the Pie as a single request. */
-    String SQL_AUDIT_OK_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_NAME +
+    public static final String SQL_AUDIT_OK_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_NAME +
                                   " FROM " + TABLE_AUDIT +
                                   " WHERE (" + COL_EVENT_TYPE   + " LIKE '" + EventConstants.TARGET_FEATURE  + "') " +
                                   " AND   (" + COL_EVENT_ACTION + " LIKE '" + EventConstants.ACTION_CHECK_OK + "') " +
@@ -191,7 +191,7 @@ public interface JdbcStoreConstants {
                                   " GROUP BY " + COL_EVENT_NAME;
     
     /** List events for a dedicate feature (in a time window). */
-    String SQL_AUDIT_FEATURE_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_ACTION +
+    public static final String SQL_AUDIT_FEATURE_DISTRIB = "SELECT count(" + COL_EVENT_UUID + ") as NB, " + COL_EVENT_ACTION +
                                      " FROM " + TABLE_AUDIT  +
                                      " WHERE (" + COL_EVENT_TYPE + " LIKE '" + EventConstants.TARGET_FEATURE  + "') " +
                                      " AND   (" + COL_EVENT_NAME + " LIKE ?) " +  
@@ -201,7 +201,7 @@ public interface JdbcStoreConstants {
     
       
     /** List events for a dedicate feature (in a time window). */
-    String SQL_AUDIT_FEATURE_ALLEVENTS = "SELECT * FROM " + TABLE_AUDIT  +      // Count
+    public static final String SQL_AUDIT_FEATURE_ALLEVENTS = "SELECT * FROM " + TABLE_AUDIT  +      // Count
                                      " WHERE (" + COL_EVENT_TYPE + " LIKE '" + EventConstants.TARGET_FEATURE  + "') " +
                                      " AND   (" + COL_EVENT_NAME + " LIKE ?) " +    // lower bound
                                      " AND   (" + COL_EVENT_TIME + "> ?) " +    // lower bound
@@ -210,45 +210,46 @@ public interface JdbcStoreConstants {
     // ----- Columns
 
     /** sql column name from table FF4J_FEATURES. */
-    String COL_FEAT_UID = "FEAT_UID";
+    public static final String COL_FEAT_UID = "FEAT_UID";
 
     /** sql column name from table FF4J_FEATURES. */
-    String COL_FEAT_ENABLE = "ENABLE";
+    public static final String COL_FEAT_ENABLE = "ENABLE";
 
     /** sql column name from table FF4J_FEATURES. */
-    String COL_FEAT_DESCRIPTION = "DESCRIPTION";
+    public static final String COL_FEAT_DESCRIPTION = "DESCRIPTION";
 
     /** sql column name from table FF4J_FEATURES. */
-    String COL_FEAT_GROUPNAME = "GROUPNAME";
+    public static final String COL_FEAT_GROUPNAME = "GROUPNAME";
 
     /** sql column name from table FF4J_FEATURES. */
-    String COL_FEAT_STRATEGY = "STRATEGY";
+    public static final String COL_FEAT_STRATEGY = "STRATEGY";
 
     /** sql column name from table FF4J_FEATURES. */
-    String COL_FEAT_EXPRESSION = "EXPRESSION";
+    public static final String COL_FEAT_EXPRESSION = "EXPRESSION";
 
     /** sql column name from table FF4J_ROLES. */
-    String COL_ROLE_FEATID = "FEAT_UID";
+    public static final String COL_ROLE_FEATID = "FEAT_UID";
 
     /** sql column name from table FF4J_ROLES. */
-    String COL_ROLE_ROLENAME = "ROLE_NAME";
+    public static final String COL_ROLE_ROLENAME = "ROLE_NAME";
     
     /** sql column name from table FF4J_PROPERTIES. */
-    String COL_PROPERTY_ID = "PROPERTY_ID";
+    public static final String COL_PROPERTY_ID = "PROPERTY_ID";
     
     /** sql column name from table FF4J_PROPERTIES. */
-    String COL_PROPERTY_TYPE = "CLAZZ";
+    public static final String COL_PROPERTY_TYPE = "CLAZZ";
     
     /** sql column name from table FF4J_PROPERTIES. */
-    String COL_PROPERTY_VALUE = "CURRENTVALUE";
+    public static final String COL_PROPERTY_VALUE = "CURRENTVALUE";
     
     /** sql column name from table FF4J_PROPERTIES. */
-    String COL_PROPERTY_FIXED = "FIXEDVALUES";
+    public static final String COL_PROPERTY_FIXED = "FIXEDVALUES";
     
     /** sql column name from table FF4J_PROPERTIES. */
-    String COL_PROPERTY_FEATID = "FEAT_UID";
+    public static final String COL_PROPERTY_FEATID = "FEAT_UID";
     
     /** sql column name from table FF4J_PROPERTIES. */
-    String COL_PROPERTY_DESCRIPTION = "DESCRIPTION";
-   
+    public static final String COL_PROPERTY_DESCRIPTION = "DESCRIPTION";
+
+    private JdbcStoreConstants() {}
 }

--- a/ff4j-core/src/main/java/org/ff4j/web/ApiConfig.java
+++ b/ff4j-core/src/main/java/org/ff4j/web/ApiConfig.java
@@ -28,12 +28,14 @@ import java.util.Set;
 
 import org.ff4j.FF4j;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Bean to configure security for the WebAPI. This custom bean is defined to limit dependencies to Spring security for instance.
  *
  * @author Cedrick Lunven (@clunven)
  */
-public class ApiConfig implements FF4JProvider, FF4jWebConstants {
+public class ApiConfig implements FF4JProvider {
     
     /** Configuration of ff4j. */
     private FF4j ff4j;

--- a/ff4j-core/src/main/java/org/ff4j/web/FF4jWebConstants.java
+++ b/ff4j-core/src/main/java/org/ff4j/web/FF4jWebConstants.java
@@ -25,103 +25,105 @@ package org.ff4j.web;
  *
  * @author Cedrick Lunven (@clunven)
  */
-public interface FF4jWebConstants {
+public class FF4jWebConstants {
 
     /** Header param sent on creation 201. */
-    String LOCATION = "Location";
+    public static final String LOCATION = "Location";
 
     /** expected post parameter from POST methods. */
-    String POST_PARAMNAME_FEATURE_UID = "uid";
+    public static final String POST_PARAMNAME_FEATURE_UID = "uid";
     
     /** parameter. */
-    String POST_PARAMNAME_CUSTOM_PREFIX = "PARAM_";
+    public static final String POST_PARAMNAME_CUSTOM_PREFIX = "PARAM_";
 
     /** Custom operation on resource. */
-    String OPERATION_ENABLE = "enable";
+    public static final String OPERATION_ENABLE = "enable";
 
     /** Custom operation on resource. */
-    String OPERATION_DISABLE = "disable";
+    public static final String OPERATION_DISABLE = "disable";
 
     /** Custom operation on resource. */
-    String OPERATION_CHECK = "check";
+    public static final String OPERATION_CHECK = "check";
 
     /** Custom operation on resource. */
-    String OPERATION_GRANTROLE = "grantrole";
+    public static final String OPERATION_GRANTROLE = "grantrole";
 
     /** Custom operation on resource. */
-    String OPERATION_REMOVEROLE = "removerole";
+    public static final String OPERATION_REMOVEROLE = "removerole";
 
     /** Custom operation on resource. */
-    String OPERATION_ADDGROUP = "addGroup";
+    public static final String OPERATION_ADDGROUP = "addGroup";
 
     /** Custom operation on resource. */
-    String OPERATION_REMOVEGROUP = "removeGroup";
+    public static final String OPERATION_REMOVEGROUP = "removeGroup";
 
     /** Custom operation on resource. */
-    String OPERATION_UPDATE = "update";
+    public static final String OPERATION_UPDATE = "update";
     
     /** relative path. */
-    String RESOURCE_FEATURES = "features";
+    public static final String RESOURCE_FEATURES = "features";
     
     /** relative path. */
-    String RESOURCE_PROPERTIES = "properties";
+    public static final String RESOURCE_PROPERTIES = "properties";
 
     /** relative path. */
-    String RESOURCE_GROUPS = "groups";
+    public static final String RESOURCE_GROUPS = "groups";
 
     /** relative path. */
-    String RESOURCE_STORE = "store";
+    public static final String RESOURCE_STORE = "store";
     
     /** relative path. */
-    String RESOURCE_PROPERTYSTORE = "propertyStore";
+    public static final String RESOURCE_PROPERTYSTORE = "propertyStore";
 
     /** relative path. */
-    String RESOURCE_MONITORING = "monitoring";
+    public static final String RESOURCE_MONITORING = "monitoring";
     
     /** relative path for security. */
-    String RESOURCE_SECURITY = "security";
+    public static final String RESOURCE_SECURITY = "security";
     
     /** relative path for cache. */
-    String RESOURCE_CACHE = "cache";
+    public static final String RESOURCE_CACHE = "cache";
     
     /** relative path for cache. */
-    String STORE_CLEAR = "clear";
+    public static final String STORE_CLEAR = "clear";
 
     /** relative path. */
-    String RESOURCE_FF4J = "ff4j";
+    public static final String RESOURCE_FF4J = "ff4j";
 
     /** list of curves. */
-    String RESOURCE_PIE = "pieChart";
+    public static final String RESOURCE_PIE = "pieChart";
     
     /** list of curves. */
-    String RESOURCE_BAR = "barChart";
+    public static final String RESOURCE_BAR = "barChart";
     
     /** filter for resource. */
-    String PARAM_START = "start";
+    public static final String PARAM_START = "start";
     
     /** featureID. */
-    String PARAM_UID = "uid";
+    public static final String PARAM_UID = "uid";
     
     /** filter for resource. */
-    String PARAM_END = "end";
+    public static final String PARAM_END = "end";
     
     /** nb of points in the curve. */
-    String PARAM_NBPOINTS = "nbpoints";
+    public static final String PARAM_NBPOINTS = "nbpoints";
 
     /** security role. */
-    String ROLE_READ = "READ";
+    public static final String ROLE_READ = "READ";
 
     /** security role. */
-    String ROLE_WRITE = "WRITE";
+    public static final String ROLE_WRITE = "WRITE";
     
     /** HTTP Parameter. */
-    String PARAM_AUTHKEY = "apiKey";
+    public static final String PARAM_AUTHKEY = "apiKey";
     
     /** HTTP Header. */
-    String HEADER_AUTHORIZATION = "Authorization";
+    public static final String HEADER_AUTHORIZATION = "Authorization";
     
     /** Manifest File. */
-    String MANIFEST_FILE = "/META-INF/MANIFEST.MF";
-    
-    String MANIFEST_VERSION = "Specification-Version";
+    public static final String MANIFEST_FILE = "/META-INF/MANIFEST.MF";
+
+    public static final String MANIFEST_VERSION = "Specification-Version";
+
+    private FF4jWebConstants() {}
 }

--- a/ff4j-core/src/test/java/org/ff4j/test/audit/AbstractEventRepositoryTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/audit/AbstractEventRepositoryTest.java
@@ -23,7 +23,6 @@ package org.ff4j.test.audit;
 import java.util.Set;
 
 import org.ff4j.audit.Event;
-import org.ff4j.audit.EventConstants;
 import org.ff4j.audit.EventPublisher;
 import org.ff4j.audit.graph.BarChart;
 import org.ff4j.audit.graph.PieChart;
@@ -33,12 +32,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.ff4j.audit.EventConstants.*;
+
 /**
  * Superclass to test {@link EventRepository}.
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public abstract class AbstractEventRepositoryTest implements EventConstants {
+public abstract class AbstractEventRepositoryTest {
     
     /** Target {@link EventRepository}. */
     protected EventRepository repo;

--- a/ff4j-core/src/test/java/org/ff4j/test/audit/EventWorkerTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/audit/EventWorkerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.ff4j.audit.Event;
-import org.ff4j.audit.EventConstants;
 import org.ff4j.audit.EventPublisher;
 import org.ff4j.audit.EventWorker;
 import org.ff4j.audit.repository.EventRepository;
@@ -34,8 +33,9 @@ import org.ff4j.audit.repository.InMemoryEventRepository;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.audit.EventConstants.*;
 
-public class EventWorkerTest implements EventConstants {
+public class EventWorkerTest {
     
     @Test
     public void testEventWorker() {

--- a/ff4j-core/src/test/java/org/ff4j/test/audit/InMemoryEventRepositoryTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/audit/InMemoryEventRepositoryTest.java
@@ -25,6 +25,8 @@ import org.ff4j.audit.repository.InMemoryEventRepository;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.audit.EventConstants.*;
+
 /**
  * Test for publisher and InMemory Event repository.
  * 

--- a/ff4j-core/src/test/java/org/ff4j/test/audit/JdbcEventRepositoryTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/audit/JdbcEventRepositoryTest.java
@@ -37,6 +37,8 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
+import static org.ff4j.audit.EventConstants.*;
+
 /**
  * Unit testing of JDBC implementation of {@link EventRepository}.
  *

--- a/ff4j-core/src/test/java/org/ff4j/test/store/JdbcFeatureDataSourceTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/store/JdbcFeatureDataSourceTest.java
@@ -26,7 +26,6 @@ import javax.sql.DataSource;
 import org.ff4j.core.FeatureStore;
 import org.ff4j.exception.FeatureAccessException;
 import org.ff4j.store.JdbcFeatureStore;
-import org.ff4j.store.JdbcStoreConstants;
 import org.ff4j.test.utils.JdbcTestHelper;
 import org.ff4j.utils.JdbcUtils;
 import org.junit.Assert;
@@ -34,12 +33,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.ff4j.store.JdbcStoreConstants.*;
+
 /**
  * This test is meant to access a Jfeature store in 'pure' JDBC.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class JdbcFeatureDataSourceTest extends FStoreTestSupport implements JdbcStoreConstants {
+public class JdbcFeatureDataSourceTest extends FStoreTestSupport {
 
     /** SQL DataSource. */
     private DataSource sqlDataSource;

--- a/ff4j-core/src/test/java/org/ff4j/test/store/JdbcFeatureStoreTestInvalidData.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/store/JdbcFeatureStoreTestInvalidData.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 
 import org.ff4j.exception.FeatureAccessException;
 import org.ff4j.store.JdbcFeatureStore;
-import org.ff4j.store.JdbcStoreConstants;
 import org.ff4j.utils.MappingUtil;
 import org.junit.After;
 import org.junit.Before;
@@ -39,7 +38,7 @@ import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class JdbcFeatureStoreTestInvalidData implements JdbcStoreConstants {
+public class JdbcFeatureStoreTestInvalidData {
 
     /** DataBase. */
     private EmbeddedDatabase db;

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/cache/FeatureCacheProviderEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/cache/FeatureCacheProviderEhCache.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.ff4j.core.Feature;
-import org.ff4j.ehcache.FF4JEhCacheConstants;
 import org.ff4j.property.Property;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +23,8 @@ import net.sf.ehcache.Cache;
 import net.sf.ehcache.CacheManager;
 import net.sf.ehcache.Element;
 import net.sf.ehcache.config.Configuration;
+
+import static org.ff4j.ehcache.FF4JEhCacheConstants.*;
 
 /**
  * Cache-aside implementation with EHCACHE.
@@ -34,7 +35,7 @@ import net.sf.ehcache.config.Configuration;
  * * Warn : DO NOT USE THIS CACHE WHEN WORKING WITH EXTERNAL FEATURESTORE (as Database) and cluster application : EACH NODE GOT
  * ITS MEMORY AND AN MODIFICATION IN STORE WON'T REFRESH THIS CACHE. Please use REDIS/MEMCACHED implementations.
  */
-public class FeatureCacheProviderEhCache implements FF4JCacheManager, FF4JEhCacheConstants {
+public class FeatureCacheProviderEhCache implements FF4JCacheManager {
 
     /** Logger for the class. */
     private static final Logger LOG = LoggerFactory.getLogger(FF4jCacheProxy.class);

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/ehcache/FF4JEhCacheConstants.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/ehcache/FF4JEhCacheConstants.java
@@ -21,18 +21,20 @@ package org.ff4j.ehcache;
  */
 
 
-public interface FF4JEhCacheConstants {
+public class FF4JEhCacheConstants {
     
     /** Default TTL is one hour. */
-    long DEFAULT_TIME_TO_LIVE = 120L;
+    public static final long DEFAULT_TIME_TO_LIVE = 120L;
 
     /** Default time to idle. */
-    long DEFAULT_TIME_TO_IDLE = 120L;
+    public static final long DEFAULT_TIME_TO_IDLE = 120L;
 
     /** Default cache name. */
-    String CACHENAME_FEATURES = "ff4jCacheFeatures";
+    public static final String CACHENAME_FEATURES = "ff4jCacheFeatures";
     
     /** Default cache name. */
-    String CACHENAME_PROPERTIES = "ff4jCacheProperties";
+    public static final String CACHENAME_PROPERTIES = "ff4jCacheProperties";
+
+    private FF4JEhCacheConstants() {}
 
 }

--- a/ff4j-store-ehcache/src/main/java/org/ff4j/store/FeatureStoreEhCache.java
+++ b/ff4j-store-ehcache/src/main/java/org/ff4j/store/FeatureStoreEhCache.java
@@ -43,7 +43,7 @@ import net.sf.ehcache.config.Configuration;
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureStoreEhCache extends AbstractFeatureStore implements FF4JEhCacheConstants {
+public class FeatureStoreEhCache extends AbstractFeatureStore {
   
     /** Wrap EHCACHE Manager. */
     private FF4jEhCacheWrapper wrapper;

--- a/ff4j-store-jcache/src/test/java/org/ff4j/cache/store/FeatureStoreJCacheTest.java
+++ b/ff4j-store-jcache/src/test/java/org/ff4j/cache/store/FeatureStoreJCacheTest.java
@@ -47,12 +47,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Test to work with Redis as a store.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureStoreJCacheTest implements TestsFf4jConstants {
+public class FeatureStoreJCacheTest {
    
     /** {@inheritDoc} */
     protected FeatureStore initStore() {

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/FeatureStoreMongoCollection.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/FeatureStoreMongoCollection.java
@@ -25,8 +25,9 @@ import org.ff4j.exception.FeatureNotFoundException;
 import org.ff4j.exception.GroupNotFoundException;
 import org.ff4j.store.mongodb.FeatureDocumentBuilder;
 import org.ff4j.store.mongodb.FeatureDocumentMapper;
-import org.ff4j.store.mongodb.FeatureStoreMongoConstants;
 import org.ff4j.utils.Util;
+
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
 
 /**
  * Implementation of {@link FeatureStore} to work with MongoDB.
@@ -34,7 +35,7 @@ import org.ff4j.utils.Util;
  * @author William Delanoue (@twillouer) </a>
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class FeatureStoreMongoCollection extends AbstractFeatureStore implements FeatureStoreMongoConstants {
+public class FeatureStoreMongoCollection extends AbstractFeatureStore {
 
     /** Map from DBObject to Feature. */
     private static final FeatureDocumentMapper MAPPER = new FeatureDocumentMapper();

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/PropertyStoreMongoCollection.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/PropertyStoreMongoCollection.java
@@ -29,18 +29,19 @@ import org.ff4j.exception.PropertyAlreadyExistException;
 import org.ff4j.property.Property;
 import org.ff4j.property.store.AbstractPropertyStore;
 import org.ff4j.store.mongodb.FeatureDocumentMapper;
-import org.ff4j.store.mongodb.FeatureStoreMongoConstants;
 import org.ff4j.store.mongodb.PropertyDocumentBuilder;
 import org.ff4j.utils.Util;
 
 import com.mongodb.client.MongoCollection;
+
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
 
 /**
  * PropertyStore based on MongoDB database.
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class PropertyStoreMongoCollection extends AbstractPropertyStore implements FeatureStoreMongoConstants {
+public class PropertyStoreMongoCollection extends AbstractPropertyStore {
 
     /** MongoDB collection. */
     private final MongoCollection<Document> collection;

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentBuilder.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentBuilder.java
@@ -25,12 +25,14 @@ import java.util.Set;
 
 import org.bson.Document;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * Mongo object builder.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public final class FeatureDocumentBuilder implements FeatureStoreMongoConstants {
+public final class FeatureDocumentBuilder {
 
     /**
      * Mongo v3 document builder.

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureDocumentMapper.java
@@ -39,12 +39,14 @@ import com.mongodb.BasicDBList;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * MApping from Mongo document to Feature.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public final class FeatureDocumentMapper implements FeatureStoreMongoConstants {
+public final class FeatureDocumentMapper {
 
     /**
      * Convert {@link Document} to {@link Feature}.

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureStoreMongoConstants.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/FeatureStoreMongoConstants.java
@@ -25,47 +25,49 @@ package org.ff4j.store.mongodb;
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public interface FeatureStoreMongoConstants {
+public class FeatureStoreMongoConstants {
 
     /** Identifier */
-    String UUID = "_id";
+    public static final String UUID = "_id";
 
     /** ENABLE */
-    String ENABLE = "enable";
+    public static final String ENABLE = "enable";
 
     /** DESCRIPTION */
-    String DESCRIPTION = "description";
+    public static final String DESCRIPTION = "description";
 
     /** Strategy. */
-    String STRATEGY = "strategy";
+    public static final String STRATEGY = "strategy";
 
     /** Expression. */
-    String EXPRESSION = "expression";
+    public static final String EXPRESSION = "expression";
 
     /** GroupName. */
-    String GROUPNAME = "groupname";
+    public static final String GROUPNAME = "groupname";
     
     /** Custom Properties. */
-    String CUSTOMPROPERTIES = "customProperties";
+    public static final String CUSTOMPROPERTIES = "customProperties";
 
     /** Roles. */
-    String ROLES = "roles";
+    public static final String ROLES = "roles";
 
     /** Custom Properties. */
-    String MONGO_SET = "$set";
+    public static final String MONGO_SET = "$set";
     
     /** Property collection attribute. */
-    String PROPERTY_NAME = "name";
+    public static final String PROPERTY_NAME = "name";
     
     /** Property collection attribute. */
-    String PROPERTY_DESCRIPTION = "description";
+    public static final String PROPERTY_DESCRIPTION = "description";
     
     /** Property collection attribute. */
-    String PROPERTY_FIXEDVALUES = "fixedValues";
+    public static final String PROPERTY_FIXEDVALUES = "fixedValues";
     
     /** Property collection attribute. */
-    String PROPERTY_TYPE = "type";
+    public static final String PROPERTY_TYPE = "type";
     
     /** Property collection attribute. */
-    String PROPERTY_VALUE = "value";
+    public static final String PROPERTY_VALUE = "value";
+
+    private FeatureStoreMongoConstants() {}
 }

--- a/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/PropertyDocumentBuilder.java
+++ b/ff4j-store-mongodb-v3/src/main/java/org/ff4j/store/mongodb/PropertyDocumentBuilder.java
@@ -26,12 +26,14 @@ import org.bson.Document;
 
 import com.mongodb.BasicDBList;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * Mongo object builder.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public final class PropertyDocumentBuilder implements FeatureStoreMongoConstants {
+public final class PropertyDocumentBuilder {
    
     /**
      * Mongo v3 document builder.

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/FeatureStoreMongoDB.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/FeatureStoreMongoDB.java
@@ -23,7 +23,6 @@ import org.ff4j.exception.FeatureNotFoundException;
 import org.ff4j.exception.GroupNotFoundException;
 import org.ff4j.store.mongodb.FeatureDBObjectBuilder;
 import org.ff4j.store.mongodb.FeatureDBObjectMapper;
-import org.ff4j.store.mongodb.FeatureStoreMongoConstants;
 import org.ff4j.utils.Util;
 
 import com.mongodb.BasicDBObject;
@@ -31,13 +30,15 @@ import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * Implementation of {@link FeatureStore} to work with MongoDB.
  * 
  * @author William Delanoue (@twillouer) </a>
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureStoreMongoDB extends AbstractFeatureStore implements FeatureStoreMongoConstants {
+public class FeatureStoreMongoDB extends AbstractFeatureStore {
 
     /** Map from DBObject to Feature. */
     private static final FeatureDBObjectMapper MAPPER = new FeatureDBObjectMapper();

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/PropertyStoreMongoDB.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/PropertyStoreMongoDB.java
@@ -39,12 +39,14 @@ import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * PropertyStore based on MongoDB database.
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class PropertyStoreMongoDB extends AbstractPropertyStore implements FeatureStoreMongoConstants {
+public class PropertyStoreMongoDB extends AbstractPropertyStore {
 
     /** MongoDB collection. */
     private final DBCollection collection;

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectBuilder.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectBuilder.java
@@ -26,12 +26,14 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * Mongo object builder.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public final class FeatureDBObjectBuilder implements FeatureStoreMongoConstants {
+public final class FeatureDBObjectBuilder {
    
     /**
      * Default builder for adds.

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectMapper.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureDBObjectMapper.java
@@ -38,12 +38,14 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSON;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * MApping from Mongo document to Feature.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public final class FeatureDBObjectMapper implements FeatureStoreMongoConstants {
+public final class FeatureDBObjectMapper {
 
     /**
      * Convert {@link DBObject} to {@link Feature}.

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureStoreMongoConstants.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/FeatureStoreMongoConstants.java
@@ -25,46 +25,48 @@ package org.ff4j.store.mongodb;
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public interface FeatureStoreMongoConstants {
+public class FeatureStoreMongoConstants {
 
     /** Identifier */
-    String UUID = "_id";
+    public static final String UUID = "_id";
 
     /** ENABLE */
-    String ENABLE = "enable";
+    public static final String ENABLE = "enable";
 
     /** DESCRIPTION */
-    String DESCRIPTION = "description";
+    public static final String DESCRIPTION = "description";
 
     /** Strategy. */
-    String STRATEGY = "strategy";
+    public static final String STRATEGY = "strategy";
 
     /** Expression. */
-    String EXPRESSION = "expression";
+    public static final String EXPRESSION = "expression";
 
     /** GroupName. */
-    String GROUPNAME = "groupname";
+    public static final String GROUPNAME = "groupname";
     
     /** Custom Properties. */
-    String CUSTOMPROPERTIES = "customProperties";
+    public static final String CUSTOMPROPERTIES = "customProperties";
     
     /** Property collection attribute. */
-    String PROPERTY_NAME = "name";
+    public static final String PROPERTY_NAME = "name";
     
     /** Property collection attribute. */
-    String PROPERTY_DESCRIPTION = "description";
+    public static final String PROPERTY_DESCRIPTION = "description";
     
     /** Property collection attribute. */
-    String PROPERTY_FIXEDVALUES = "fixedValues";
+    public static final String PROPERTY_FIXEDVALUES = "fixedValues";
     
     /** Property collection attribute. */
-    String PROPERTY_TYPE = "type";
+    public static final String PROPERTY_TYPE = "type";
     
     /** Property collection attribute. */
-    String PROPERTY_VALUE = "value";
+    public static final String PROPERTY_VALUE = "value";
 
     /** Roles. */
-    String ROLES = "roles";
+    public static final String ROLES = "roles";
 
-    String MONGO_SET = "$set";
+    public static final String MONGO_SET = "$set";
+
+    private FeatureStoreMongoConstants() {}
 }

--- a/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/PropertyDBObjectBuilder.java
+++ b/ff4j-store-mongodb/src/main/java/org/ff4j/store/mongodb/PropertyDBObjectBuilder.java
@@ -26,12 +26,14 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
 
+import static org.ff4j.store.mongodb.FeatureStoreMongoConstants.*;
+
 /**
  * Mongo object builder.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public final class PropertyDBObjectBuilder implements FeatureStoreMongoConstants {
+public final class PropertyDBObjectBuilder {
    
     /**
      * Default builder for adds.

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/FF4jNeo4jConstants.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/FF4jNeo4jConstants.java
@@ -26,58 +26,58 @@ package org.ff4j.neo4j;
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public interface FF4jNeo4jConstants {
+public class FF4jNeo4jConstants {
     
     /** Cypher query alias. */
-    String QUERY_CYPHER_ALIAS = "NB";
+    public static final String QUERY_CYPHER_ALIAS = "NB";
     
     // -------------------------------------------------------
     // --------------------- Attributes  ---------------------  
     // -------------------------------------------------------
     
     /** core attribute. */
-    String NODEFEATURE_ATT_UID = "uid";
+    public static final String NODEFEATURE_ATT_UID = "uid";
     
     /** core attribute. */
-    String NODEFEATURE_ATT_ENABLE = "enable";
+    public static final String NODEFEATURE_ATT_ENABLE = "enable";
     
     /** core attribute. */
-    String NODEFEATURE_ATT_ROLES= "roles";
+    public static final String NODEFEATURE_ATT_ROLES= "roles";
     
     /** core attribute. */
-    String NODEFEATURE_ATT_DESCRIPTION= "description";
+    public static final String NODEFEATURE_ATT_DESCRIPTION= "description";
     
     /** core attribute. */
-    String NODESTRATEGY_ATT_TYPE = "type";
+    public static final String NODESTRATEGY_ATT_TYPE = "type";
     
     /** core attribute. */
-    String NODESTRATEGY_ATT_INITPARAMS = "initParams";
+    public static final String NODESTRATEGY_ATT_INITPARAMS = "initParams";
     
     /** core attribute. */
-    String NODEPROPERTY_ATT_NAME = "name";
+    public static final String NODEPROPERTY_ATT_NAME = "name";
     
     /** core attribute. */
-    String NODEPROPERTY_ATT_DESCRIPTION = "description";
+    public static final String NODEPROPERTY_ATT_DESCRIPTION = "description";
     
     /** core attribute. */
-    String NODEPROPERTY_ATT_VALUE = "value";
+    public static final String NODEPROPERTY_ATT_VALUE = "value";
     
     /** core attribute. */
-    String NODEPROPERTY_ATT_FIXEDVALUES = "fixedValues";
+    public static final String NODEPROPERTY_ATT_FIXEDVALUES = "fixedValues";
     
     /** core attribute. */
-    String NODEPROPERTY_ATT_TYPE = "type";
+    public static final String NODEPROPERTY_ATT_TYPE = "type";
     
     /** core attribute. */
-    String NODEGROUP_ATT_NAME= "name";
+    public static final String NODEGROUP_ATT_NAME= "name";
     
     // -------------------------------------------------------
     // --------------------- Create  -------------------------  
     // -------------------------------------------------------
 
-    String MATCH_F = "MATCH (f:";
+    public static final String MATCH_F = "MATCH (f:";
     /** Cypher query. */
-    String QUERY_CYPHER_ADDTO_GROUP = 
+    public static final String QUERY_CYPHER_ADDTO_GROUP =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + "  {uid: {uid} } ), " +
             "(g:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + " {name: {groupName} }) " + 
             "CREATE (f)-[:" + FF4jNeo4jRelationShips.MEMBER_OF + "]->(g);";
@@ -86,78 +86,78 @@ public interface FF4jNeo4jConstants {
     // --------------------- Read ----------------------------
     // -------------------------------------------------------
 
-    String RETURN_COUNT_AS = "RETURN count(*) AS ";
+    public static final String RETURN_COUNT_AS = "RETURN count(*) AS ";
     /** Cypher query. */
-    String QUERY_CYPHER_EXISTS  = 
+    public static final String QUERY_CYPHER_EXISTS  =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid:  {uid} }) " +
                     RETURN_COUNT_AS + QUERY_CYPHER_ALIAS;
 
-    String MATCH_P = "MATCH (p:";
-    String QUERY_CYPHER_EXISTS_PROPERTY  =
+    public static final String MATCH_P = "MATCH (p:";
+    public static final String QUERY_CYPHER_EXISTS_PROPERTY  =
             MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name:  {name} }) " +
                     RETURN_COUNT_AS + QUERY_CYPHER_ALIAS;
-    
-    String QUERY_CYPHER_EXISTS_GROUP =
+
+    public static final String QUERY_CYPHER_EXISTS_GROUP =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + " { name:  {groupName} }) " +
                     RETURN_COUNT_AS + QUERY_CYPHER_ALIAS;
             
     /** Cypher query. */
-    String QUERY_CYPHER_READ_FEATURE = 
+    public static final String QUERY_CYPHER_READ_FEATURE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(all) RETURN f,all";
     
     /** Cypher query. */
-    String QUERY_CYPHER_READ_PROPERTY = 
+    public static final String QUERY_CYPHER_READ_PROPERTY =
             MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name} }) RETURN p";
     
     /** Cypher query. */
-    String QUERY_CYPHER_NORELATIONSHIPS = 
+    public static final String QUERY_CYPHER_NORELATIONSHIPS =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) RETURN f;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_READ_ALL = 
+    public static final String QUERY_CYPHER_READ_ALL =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + ")--(all) RETURN f,all;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_READ_ALLPROPERTIES = 
+    public static final String QUERY_CYPHER_READ_ALLPROPERTIES =
             MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + ") RETURN p;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_READ_SINGLE = 
+    public static final String QUERY_CYPHER_READ_SINGLE =
             "MATCH (f:FF4J_FEATURE) RETURN f;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_GETGROUPNAME = 
+    public static final String QUERY_CYPHER_GETGROUPNAME =
             "MATCH(f:" + FF4jNeo4jLabels.FF4J_FEATURE + "  { uid:  {uid} } ) " + 
              "--(g:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + ") " + 
              "RETURN g.name as GROUPNAME;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_GET_FLIPPINGSTRATEGY = 
+    public static final String QUERY_CYPHER_GET_FLIPPINGSTRATEGY =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })" +
             "--(s:" + FF4jNeo4jLabels.FF4J_FLIPPING_STRATEGY + ") " + 
             "RETURN s;";
 
-    String NAME_GROUP_NAME = "]-( { name: {groupName} }) ";
-    String WHERE_F = "WHERE (f)-[:";
+    public static final String NAME_GROUP_NAME = "]-( { name: {groupName} }) ";
+    public static final String WHERE_F = "WHERE (f)-[:";
     /** Cypher query. */
-    String QUERY_CYPHER_COUNT_FEATURE_OF_GROUP = 
+    public static final String QUERY_CYPHER_COUNT_FEATURE_OF_GROUP =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
                     WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "RETURN COUNT(*) AS " + QUERY_CYPHER_ALIAS + ";";
     
     /** Cypher query. */
-    String QUERY_CYPHER_READ_FEATURES_OF_GROUP = 
+    public static final String QUERY_CYPHER_READ_FEATURES_OF_GROUP =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
                     WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "RETURN f.uid AS UID;";
     
     /** Cypher query. */
-    String QUERY_READ_GROUPS = 
+    public static final String QUERY_READ_GROUPS =
             "MATCH (g:" +  FF4jNeo4jLabels.FF4J_FEATURE_GROUP + "  ) " + 
             "RETURN g.name AS GROUPNAME;";
     
     /** Cypher query. */
-    String QUERY_READ_PROPERTYNAMES = 
+    public static final String QUERY_READ_PROPERTYNAMES =
             MATCH_P +  FF4jNeo4jLabels.FF4J_PROPERTY + "  ) " +
             "RETURN p.name AS NAME;";
     
@@ -166,40 +166,40 @@ public interface FF4jNeo4jConstants {
     // -------------------------------------------------------
     
     /** Cypher query. */
-    String QUERY_CYPHER_ENABLE  = 
+    public static final String QUERY_CYPHER_ENABLE  =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) " +
             "SET f.enable = true RETURN f.enable;";
     
     
     /** Cypher query. */
-    String QUERY_CYPHER_UPDATE_PROPERTYVALUE  = 
+    public static final String QUERY_CYPHER_UPDATE_PROPERTYVALUE  =
             MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name} }) " +
             "SET p." + NODEPROPERTY_ATT_VALUE + "= {value};";
     
     /** Cypher query. */
-    String QUERY_CYPHER_DISABLE = 
+    public static final String QUERY_CYPHER_DISABLE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} }) " +
             "SET f.enable = false RETURN f.enable;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_ADD_ROLE = 
+    public static final String QUERY_CYPHER_ADD_ROLE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + "  {uid: {uid} }) " +
             "SET f.roles = f.roles + {roleName} return f;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_ENABLE_GROUP = 
+    public static final String QUERY_CYPHER_ENABLE_GROUP =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
                     WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "SET f.enable = true RETURN f.enable;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_DISABLE_GROUP = 
+    public static final String QUERY_CYPHER_DISABLE_GROUP =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " ) " +
                     WHERE_F + FF4jNeo4jRelationShips.MEMBER_OF + NAME_GROUP_NAME +
             "SET f.enable = false RETURN f.enable;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_UPDATE_ROLE = 
+    public static final String QUERY_CYPHER_UPDATE_ROLE =
             "MATCH (f:FF4J_FEATURE { uid: {uid}  }) " + 
             "SET f.roles = {roles} RETURN f";
     
@@ -208,48 +208,49 @@ public interface FF4jNeo4jConstants {
     // -------------------------------------------------------
     
     /** Delete properties related to the feature. */
-    String QUERY_CYPHER_DELETE_PROPERTIES_FEATURE = 
+    public static final String QUERY_CYPHER_DELETE_PROPERTIES_FEATURE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(p:" + FF4jNeo4jLabels.FF4J_FEATURE_PROPERTY + " ) "  +
             "DETACH DELETE p;";
     
     /** Delete flipping strategy related to the feature. */
-    String QUERY_CYPHER_DELETE_STRATEGY_FEATURE = 
+    public static final String QUERY_CYPHER_DELETE_STRATEGY_FEATURE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(s:" + FF4jNeo4jLabels.FF4J_FLIPPING_STRATEGY + ") "  +
             "DETACH DELETE s;";
 
     /** Delete flipping strategy related to the feature. */
-    String QUERY_CYPHER_DELETE_GROUP_FEATURE = 
+    public static final String QUERY_CYPHER_DELETE_GROUP_FEATURE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })--(s:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + ") "  +
             "DETACH DELETE s;";
     
     /** Delete Feature with all its relationships*/
-    String QUERY_CYPHER_DELETE_FEATURE = 
+    public static final String QUERY_CYPHER_DELETE_FEATURE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid}  }) " +
             "DETACH DELETE f;";
     
     /** Delete property. */
-    String QUERY_CYPHER_DELETE_PROPERTY = 
+    public static final String QUERY_CYPHER_DELETE_PROPERTY =
             MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + " { name: {name}  }) " +
                     "DETACH DELETE p;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_REMOVEFROMGROUP = 
+    public static final String QUERY_CYPHER_REMOVEFROMGROUP =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + " { uid: {uid} })-[a:" + FF4jNeo4jRelationShips.MEMBER_OF + "]->() DELETE a;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_DELETE_GROUP = 
+    public static final String QUERY_CYPHER_DELETE_GROUP =
             "MATCH (g:" + FF4jNeo4jLabels.FF4J_FEATURE_GROUP + " { name: {groupName} }) DETACH DELETE g;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_DELETE_ALLFEATURE = 
+    public static final String QUERY_CYPHER_DELETE_ALLFEATURE =
             "MATCH (f:FF4J_FEATURE)--(all) DETACH DELETE f, all;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_DELETE_ALLSINGLEFEATURE = 
+    public static final String QUERY_CYPHER_DELETE_ALLSINGLEFEATURE =
             MATCH_F + FF4jNeo4jLabels.FF4J_FEATURE + ") DETACH DELETE f;";
     
     /** Cypher query. */
-    String QUERY_CYPHER_DELETE_ALLPROPERTY = 
+    public static final String QUERY_CYPHER_DELETE_ALLPROPERTY =
             MATCH_P + FF4jNeo4jLabels.FF4J_PROPERTY + ") DETACH DELETE p;";
 
+    private FF4jNeo4jConstants() {}
 }

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/mapper/Neo4jMapper.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/mapper/Neo4jMapper.java
@@ -28,19 +28,20 @@ import java.util.Set;
 
 import org.ff4j.core.Feature;
 import org.ff4j.core.FlippingStrategy;
-import org.ff4j.neo4j.FF4jNeo4jConstants;
 import org.ff4j.property.Property;
 import org.ff4j.property.PropertyString;
 import org.ff4j.property.util.PropertyFactory;
 import org.ff4j.utils.MappingUtil;
 import org.neo4j.graphdb.Node;
 
+import static org.ff4j.neo4j.FF4jNeo4jConstants.*;
+
 /**
  * Map Neo4j node from and to {@link Feature} bean.
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class Neo4jMapper implements FF4jNeo4jConstants {
+public class Neo4jMapper {
     
     /**
      * Hide default constructor.

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/FeatureStoreNeo4J.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/FeatureStoreNeo4J.java
@@ -33,7 +33,6 @@ import org.ff4j.core.Feature;
 import org.ff4j.core.FlippingStrategy;
 import org.ff4j.exception.FeatureAlreadyExistException;
 import org.ff4j.exception.FeatureNotFoundException;
-import org.ff4j.neo4j.FF4jNeo4jConstants;
 import org.ff4j.neo4j.FF4jNeo4jLabels;
 import org.ff4j.neo4j.FF4jNeo4jRelationShips;
 import org.ff4j.property.Property;
@@ -44,12 +43,14 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 
+import static org.ff4j.neo4j.FF4jNeo4jConstants.*;
+
 /**
  * Implementatino of NEO4J Store.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureStoreNeo4J extends AbstractFeatureStore implements FF4jNeo4jConstants {
+public class FeatureStoreNeo4J extends AbstractFeatureStore {
 
     public static final String GROUPNAME = "GROUPNAME";
     public static final String GROUP_NAME = "groupName";

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/PropertyStoreNeo4j.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/PropertyStoreNeo4j.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.ff4j.exception.PropertyAlreadyExistException;
-import org.ff4j.neo4j.FF4jNeo4jConstants;
 import org.ff4j.neo4j.FF4jNeo4jLabels;
 import org.ff4j.neo4j.mapper.Neo4jMapper;
 import org.ff4j.property.Property;
@@ -39,12 +38,14 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 
+import static org.ff4j.neo4j.FF4jNeo4jConstants.*;
+
 /**
  *Implementation of {@link PropertyStore} to work with Neo4J.
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class PropertyStoreNeo4j extends AbstractPropertyStore implements FF4jNeo4jConstants {
+public class PropertyStoreNeo4j extends AbstractPropertyStore {
     
     /** Persistent storage. */
     private GraphDatabaseService graphDb;

--- a/ff4j-store-neo4j/src/test/java/org/ff4j/neo4j/FeatureStoreNeo4jLimitTest.java
+++ b/ff4j-store-neo4j/src/test/java/org/ff4j/neo4j/FeatureStoreNeo4jLimitTest.java
@@ -37,7 +37,9 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-public class FeatureStoreNeo4jLimitTest implements FF4jNeo4jConstants {
+import static org.ff4j.neo4j.FF4jNeo4jConstants.*;
+
+public class FeatureStoreNeo4jLimitTest {
 
     /** DataBase instance. */
     protected static GraphDatabaseService graphDb;

--- a/ff4j-store-neo4j/src/test/java/org/ff4j/neo4j/FeatureStoreNeo4jTest.java
+++ b/ff4j-store-neo4j/src/test/java/org/ff4j/neo4j/FeatureStoreNeo4jTest.java
@@ -31,12 +31,14 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import static org.ff4j.neo4j.FF4jNeo4jConstants.*;
+
 /**
  * Unit Testing for Neo4j store.
  * 
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class FeatureStoreNeo4jTest extends FeatureStoreTestSupport implements FF4jNeo4jConstants {
+public class FeatureStoreNeo4jTest extends FeatureStoreTestSupport {
 
     /** DataBase instance. */
     protected static GraphDatabaseService graphDb;

--- a/ff4j-store-neo4j/src/test/java/org/ff4j/neo4j/PropertyStoreNeo4jTest.java
+++ b/ff4j-store-neo4j/src/test/java/org/ff4j/neo4j/PropertyStoreNeo4jTest.java
@@ -33,12 +33,14 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import static org.ff4j.neo4j.FF4jNeo4jConstants.*;
+
 /**
  * Unit testing of property with Neo4j.
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class PropertyStoreNeo4jTest extends PropertyStoreTestSupport implements FF4jNeo4jConstants {
+public class PropertyStoreNeo4jTest extends PropertyStoreTestSupport {
 
     /** DataBase instance. */
     protected static GraphDatabaseService graphDb;

--- a/ff4j-store-redis/src/test/java/org/ff4j/cache/RedisCacheManagerTestIT.java
+++ b/ff4j-store-redis/src/test/java/org/ff4j/cache/RedisCacheManagerTestIT.java
@@ -3,10 +3,11 @@ package org.ff4j.cache;
 import org.ff4j.core.Feature;
 import org.ff4j.core.FeatureStore;
 import org.ff4j.store.InMemoryFeatureStore;
-import org.ff4j.test.TestsFf4jConstants;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.ff4j.test.TestsFf4jConstants.*;
 
 /*
  * #%L
@@ -28,7 +29,7 @@ import org.junit.Test;
  * #L%
  */
 @Ignore
-public class RedisCacheManagerTestIT implements TestsFf4jConstants {
+public class RedisCacheManagerTestIT {
 
     @Test
     public void testPutGet() {

--- a/ff4j-store-redis/src/test/java/org/ff4j/cache/it/FeatureStoreWithRedisCacheTestIT.java
+++ b/ff4j-store-redis/src/test/java/org/ff4j/cache/it/FeatureStoreWithRedisCacheTestIT.java
@@ -36,6 +36,8 @@ import org.ff4j.test.store.FeatureStoreTestSupport;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Class to test the REDIS {@link FeatureCacheProviderEhCache}.
  * 

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/FeatureStoreSpringJdbc.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/FeatureStoreSpringJdbc.java
@@ -37,13 +37,15 @@ import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import static org.ff4j.store.JdbcStoreConstants.*;
+
 /**
  * Implementation of {@link FeatureStore} to work with RDBMS through JDBC.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
 @Repository
-public class FeatureStoreSpringJdbc extends AbstractFeatureStore implements JdbcStoreConstants {
+public class FeatureStoreSpringJdbc extends AbstractFeatureStore {
 
     /** Row Mapper for FlipPoint. */
     private static final FeatureRowMapper FMAPPER = new FeatureRowMapper();

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/PropertyStoreSpringJdbc.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/PropertyStoreSpringJdbc.java
@@ -4,6 +4,8 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import static org.ff4j.store.JdbcStoreConstants.*;
+
 /*
  * #%L
  * ff4j-store-springjdbc
@@ -48,7 +50,7 @@ import org.springframework.stereotype.Repository;
  * @author Cedrick Lunven (@clunven)</a>
  */
 @Repository
-public class PropertyStoreSpringJdbc extends AbstractPropertyStore implements JdbcStoreConstants {
+public class PropertyStoreSpringJdbc extends AbstractPropertyStore {
 
     /** target mapper. */
     private static CustomPropertyRowMapper PMAPPER = new CustomPropertyRowMapper();

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/FeatureRowMapper.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/FeatureRowMapper.java
@@ -26,16 +26,17 @@ import java.util.Map;
 
 import org.ff4j.core.Feature;
 import org.ff4j.core.FlippingStrategy;
-import org.ff4j.store.JdbcStoreConstants;
 import org.ff4j.utils.MappingUtil;
 import org.springframework.jdbc.core.RowMapper;
+
+import static org.ff4j.store.JdbcStoreConstants.*;
 
 /**
  * Mapper to convert result into
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureRowMapper implements RowMapper<Feature>, JdbcStoreConstants {
+public class FeatureRowMapper implements RowMapper<Feature> {
 
     /** {@inheritDoc} */
     @Override

--- a/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/RoleRowMapper.java
+++ b/ff4j-store-springjdbc/src/main/java/org/ff4j/store/rowmapper/RoleRowMapper.java
@@ -27,15 +27,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.ff4j.store.JdbcStoreConstants;
 import org.springframework.jdbc.core.RowMapper;
+
+import static org.ff4j.store.JdbcStoreConstants.*;
 
 /**
  * Implementation of JDBC store using Spring JDBC.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class RoleRowMapper implements RowMapper<Integer>, JdbcStoreConstants {
+public class RoleRowMapper implements RowMapper<Integer> {
 
     /** Default Row Mapper to get groups. */
     private final Map<String, Set<String>> roles = new HashMap<String, Set<String>>();

--- a/ff4j-store-springjdbc/src/test/java/org/ff4j/test/store/SpringJdbcXMLDataSourceStoreTest.java
+++ b/ff4j-store-springjdbc/src/test/java/org/ff4j/test/store/SpringJdbcXMLDataSourceStoreTest.java
@@ -26,6 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Testing JDBC Store with spring ans conf as XML.
  * 

--- a/ff4j-test/src/main/java/org/ff4j/test/TestsFf4jConstants.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/TestsFf4jConstants.java
@@ -25,60 +25,62 @@ package org.ff4j.test;
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public interface TestsFf4jConstants {
+public class TestsFf4jConstants {
 
     /** Initial feature number. */
-    int EXPECTED_FEATURES_NUMBERS = 5;
+    public static final int EXPECTED_FEATURES_NUMBERS = 5;
 
     /** Feature Name. */
-    String F1 = "first";
+    public static final String F1 = "first";
 
     /** Feature Name. */
-    String F2 = "second";
+    public static final String F2 = "second";
 
     /** Feature Name. */
-    String F3 = "third";
+    public static final String F3 = "third";
 
     /** Feature Name. */
-    String F4 = "forth";
+    public static final String F4 = "forth";
 
     /** Feature Name. */
-    String AWESOME = "AwesomeFeature";
+    public static final String AWESOME = "AwesomeFeature";
 
     /** Custom property name. */
-    String CUSTOM_PROPERTY = "KEY-1";
+    public static final String CUSTOM_PROPERTY = "KEY-1";
 
     /** Group Name. */
-    String G0 = "GRP0";
+    public static final String G0 = "GRP0";
 
     /** Group Name. */
-    String G1 = "GRP1";
+    public static final String G1 = "GRP1";
 
     /** Group Name. */
-    String F_DOESNOTEXIST = "invalid-feature-id";
+    public static final String F_DOESNOTEXIST = "invalid-feature-id";
 
     /** Group Name. */
-    String G_DOESNOTEXIST = "invalid-group-name";
+    public static final String G_DOESNOTEXIST = "invalid-group-name";
 
     /** Feature Name. */
-    String FEATURE_NEW = "new";
+    public static final String FEATURE_NEW = "new";
 
     /** Feature Name. */
-    String FEATURE_X = "x";
+    public static final String FEATURE_X = "x";
 
     /** Feature Name. */
-    String ROLE_USER = "USER";
+    public static final String ROLE_USER = "USER";
 
     /** Feature Name. */
-    String ROLE_ADMIN = "ADMINISTRATOR";
+    public static final String ROLE_ADMIN = "ADMINISTRATOR";
 
     /** Feature Name. */
-    String ROLE_TEST = "BETA-TESTER";
+    public static final String ROLE_TEST = "BETA-TESTER";
 
     /** Feature Name. */
-    String ROLE_NEW = "ROLE_NEW";
+    public static final String ROLE_NEW = "ROLE_NEW";
 
     /** Test file. */
-    String TEST_FEATURES_FILE = "test-ff4j-features.xml";
+    public static final String TEST_FEATURES_FILE = "test-ff4j-features.xml";
+
+    private TestsFf4jConstants() {}
 
 }

--- a/ff4j-test/src/main/java/org/ff4j/test/cache/AbstractCacheManagerJUnitTest.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/cache/AbstractCacheManagerJUnitTest.java
@@ -22,18 +22,19 @@ package org.ff4j.test.cache;
 
 import org.ff4j.cache.FF4JCacheManager;
 import org.ff4j.core.Feature;
-import org.ff4j.test.TestsFf4jConstants;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.ff4j.test.TestsFf4jConstants.*;
 
 /**
  * Cache manager.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public abstract class AbstractCacheManagerJUnitTest implements TestsFf4jConstants {
+public abstract class AbstractCacheManagerJUnitTest {
 
     public static final String DESCRIPTION = "Description";
     /** Cache Manager. */

--- a/ff4j-test/src/main/java/org/ff4j/test/store/FeatureStoreTestSupport.java
+++ b/ff4j-test/src/main/java/org/ff4j/test/store/FeatureStoreTestSupport.java
@@ -28,18 +28,19 @@ import org.ff4j.property.PropertyString;
 import org.ff4j.store.InMemoryFeatureStore;
 import org.ff4j.strategy.PonderationStrategy;
 import org.ff4j.test.AssertFf4j;
-import org.ff4j.test.TestsFf4jConstants;
 import org.ff4j.utils.Util;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.ff4j.test.TestsFf4jConstants.*;
 
 /**
  * For different store.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public abstract class FeatureStoreTestSupport implements TestsFf4jConstants {
+public abstract class FeatureStoreTestSupport {
 
     public static final String GOLOGOLO = "GOLOGOLO";
     public static final String ROLE_XYZ = "ROLE_XYZ";

--- a/ff4j-web/src/main/java/org/ff4j/web/FF4jInitServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/FF4jInitServlet.java
@@ -24,16 +24,17 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 
-import org.ff4j.web.embedded.ConsoleConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.ff4j.web.embedded.ConsoleConstants.*;
 
 /**
  * Servlet initialisation to put FF4J in HTTP Session.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FF4jInitServlet extends HttpServlet implements ConsoleConstants {
+public class FF4jInitServlet extends HttpServlet {
 
     /** Serial. */
     private static final long serialVersionUID = 8447941463286918975L;

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleConstants.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleConstants.java
@@ -25,194 +25,196 @@ package org.ff4j.web.embedded;
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public interface ConsoleConstants {
+public class ConsoleConstants {
 
     
     // -------- CONTENT-TYPE ------------------------------
 
     /** Content type for response. */
-    String CONTENT_TYPE_HTML = "text/html";
+    public static final String CONTENT_TYPE_HTML = "text/html";
 
     /** Content type for response. */
-    String CONTENT_TYPE_CSS = "text/css";
+    public static final String CONTENT_TYPE_CSS = "text/css";
 
     /** Content type for response. */
-    String CONTENT_TYPE_JS = "application/javascript";
+    public static final String CONTENT_TYPE_JS = "application/javascript";
     
     /** Content type for response. */
-    String CONTENT_TYPE_JSON = "application/json";
+    public static final String CONTENT_TYPE_JSON = "application/json";
 
 
     // -------- RESOURCES ------------------------------
 
     /** static resource param name. */
-    String RESOURCE = "rsc";
+    public static final String RESOURCE = "rsc";
 
     /** static resource paramv alue. */
-    String RESOURCE_CSS_PARAM = "css";
+    public static final String RESOURCE_CSS_PARAM = "css";
 
     /** static resource file. */
-    String RESOURCE_CSS_FILE = "ff4j-embedded.css";
+    public static final String RESOURCE_CSS_FILE = "ff4j-embedded.css";
 
     /** static resource param value. */
-    String RESOURCE_JS_PARAM = "js";
+    public static final String RESOURCE_JS_PARAM = "js";
 
     /** static resource file. */
-    String RESOURCE_JS_FILE = "ff4j-embedded.js";
+    public static final String RESOURCE_JS_FILE = "ff4j-embedded.js";
 
 
     // -------- OPERATIONS ------------------------------
 
     /** POST - Operation. */
-    String OPERATION = "op";
+    public static final String OPERATION = "op";
 
     /** POST - Operation. */
-    String SUBOPERATION = "ope";
+    public static final String SUBOPERATION = "ope";
 
     /** User operation. */
-    String OP_CREATE_FEATURE = "create";
+    public static final String OP_CREATE_FEATURE = "create";
     
     /** User operation. */
-    String OP_CREATE_PROPERTY = "createProperty";
+    public static final String OP_CREATE_PROPERTY = "createProperty";
 
     /** User operation. */
-    String OP_EDIT_FEATURE = "update";
+    public static final String OP_EDIT_FEATURE = "update";
     
     /** User operation. */
-    String OP_EDIT_PROPERTY = "updateProperty";
+    public static final String OP_EDIT_PROPERTY = "updateProperty";
 
     /** User operation: remove feature. */
-    String OP_RMV_FEATURE = "delete";
+    public static final String OP_RMV_FEATURE = "delete";
     
     /** User operation: remove feature. */
-    String OP_RMV_PROPERTY = "deleteProperty";
+    public static final String OP_RMV_PROPERTY = "deleteProperty";
     
     /** User operation: remove feature. */
-    String OP_READ_PROPERTY = "readProperty";
+    public static final String OP_READ_PROPERTY = "readProperty";
     
     /** remove a value of a listed. */
-    String OP_DELETE_FIXEDVALUE = "deleteFixedValue";
+    public static final String OP_DELETE_FIXEDVALUE = "deleteFixedValue";
     
     /** remove a value of a listed. */
-    String OP_ADD_FIXEDVALUE = "addFixedValue";
+    public static final String OP_ADD_FIXEDVALUE = "addFixedValue";
 
     /** User operation. */
-    String OP_TOGGLE_GROUP = "toggleGroup";
+    public static final String OP_TOGGLE_GROUP = "toggleGroup";
     
     /** User operation: remove feature. */
-    String OP_READ_FEATURE = "readFeature";
+    public static final String OP_READ_FEATURE = "readFeature";
 
     /** User operation. */
-    String OP_ENABLE = "enable";
+    public static final String OP_ENABLE = "enable";
 
     /** User operation. */
-    String OP_DISABLE = "disable";
+    public static final String OP_DISABLE = "disable";
 
     /** User operation. */
-    String OP_IMPORT = "import";
+    public static final String OP_IMPORT = "import";
 
     /** User operation. */
-    String OP_EXPORT = "export";
+    public static final String OP_EXPORT = "export";
 
 
     // -------- TEMPLATING ------------------------------
 
     /** Header. */
-    String TEMPLATE_FILE = "ff4j-template.html";
+    public static final String TEMPLATE_FILE = "ff4j-template.html";
 
     /** templating. */
-    String KEY_SERVLET_CONTEXT = "SERVLET_CONTEXT";
+    public static final String KEY_SERVLET_CONTEXT = "SERVLET_CONTEXT";
 
     /** templating. */
-    String KEY_VERSION = "VERSION";
+    public static final String KEY_VERSION = "VERSION";
 
     /** templating. */
-    String KEY_FEATURE_ROWS = "FEATURE_ROWS";
+    public static final String KEY_FEATURE_ROWS = "FEATURE_ROWS";
     
     /** templating. */
-    String KEY_PROPERTIES_ROWS = "PROPERTIES_ROWS";
+    public static final String KEY_PROPERTIES_ROWS = "PROPERTIES_ROWS";
 
     /** templating. */
-    String KEY_GROUP_LIST_EDIT = "FEATURE_GRPS_EDIT";
+    public static final String KEY_GROUP_LIST_EDIT = "FEATURE_GRPS_EDIT";
 
     /** templating. */
-    String KEY_GROUP_LIST_CREATE = "FEATURE_GRPS_CREATE";
+    public static final String KEY_GROUP_LIST_CREATE = "FEATURE_GRPS_CREATE";
 
     /** templating. */
-    String KEY_GROUP_LIST_TOGGLE = "FEATURE_GRPS_TOGGLE";
+    public static final String KEY_GROUP_LIST_TOGGLE = "FEATURE_GRPS_TOGGLE";
 
     /** templating alert. */
-    String KEY_ALERT_MESSAGE = "ALERT";
+    public static final String KEY_ALERT_MESSAGE = "ALERT";
 
     /** templating. */
-    String KEY_PERMISSIONLIST = "PERMISSIONS";
+    public static final String KEY_PERMISSIONLIST = "PERMISSIONS";
 
 
     // -------- FORM PARAM ------------------------------
 
     /** HTTP Parameter. */
-    String FEATID = "uid";
+    public static final String FEATID = "uid";
 
     /** HTTP Parameter. */
-    String ROLE = "role";
+    public static final String ROLE = "role";
 
     /** HTTP Parameter. */
-    String DESCRIPTION = "desc";
+    public static final String DESCRIPTION = "desc";
 
     /** HTTP Parameter. */
-    String FLIPFILE = "flipFile";
+    public static final String FLIPFILE = "flipFile";
     
     /** HTTP Parameter. */
-    String GROUPNAME = "groupName";
+    public static final String GROUPNAME = "groupName";
 
     /** HTTP Parameter. */
-    String STRATEGY = "strategy";
+    public static final String STRATEGY = "strategy";
     
     /** HTTP Parameter. */
-    String STRATEGY_INIT = "initParams";
+    public static final String STRATEGY_INIT = "initParams";
 
     /** HTTP Parameter. */
-    String PERMISSION = "permission";
+    public static final String PERMISSION = "permission";
     
     /** HTTP Parameter. */
-    String NAME = "name";
+    public static final String NAME = "name";
 
     // -------- MISC ------------------------------
 
     /** File encoding. */
-    String UTF8_ENCODING = "UTF-8";
+    public static final String UTF8_ENCODING = "UTF-8";
 
     /** NewLine. */
-    String NEW_LINE = System.getProperty("line.separator");
+    public static final String NEW_LINE = System.getProperty("line.separator");
 
     /** buffer size. */
-    int BUFFER_SIZE = 4096;
+    public static final int BUFFER_SIZE = 4096;
 
     /** servlet init param. */
-    String PROVIDER_PARAM_NAME = "ff4jProvider";
+    public static final String PROVIDER_PARAM_NAME = "ff4jProvider";
 
     /** attribute name. */
-    String FF4J_SESSIONATTRIBUTE_NAME = "FF4J";
+    public static final String FF4J_SESSIONATTRIBUTE_NAME = "FF4J";
 
     /** attribute name. */
-    String PREFIX_CHECKBOX = "perm-check-";
+    public static final String PREFIX_CHECKBOX = "perm-check-";
 
     /** permission. */
-    String PERMISSION_PUBLIC = "Public";
+    public static final String PERMISSION_PUBLIC = "Public";
 
     /** permission. */
-    String PERMISSION_RESTRICTED = "Restricted";
+    public static final String PERMISSION_RESTRICTED = "Restricted";
 
     /** modal id. */
-    String MODAL_EDIT = "modalEdit";
+    public static final String MODAL_EDIT = "modalEdit";
 
     /** modal ID. */
-    String MODAL_CREATE = "modalCreate";
+    public static final String MODAL_CREATE = "modalCreate";
 
     /** modal ID. */
-    String MODAL_TOGGLE = "modalToggle";
+    public static final String MODAL_TOGGLE = "modalToggle";
     
     /** FixedValue to be remove. */
-    String PARAM_FIXEDVALUE = "fixedValue";
+    public static final String PARAM_FIXEDVALUE = "fixedValue";
+
+    private ConsoleConstants() {}
 
 }

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleOperations.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleOperations.java
@@ -45,7 +45,9 @@ import org.ff4j.property.util.PropertyFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class ConsoleOperations implements ConsoleConstants {
+import static org.ff4j.web.embedded.ConsoleConstants.*;
+
+public final class ConsoleOperations {
     
     /** Logger for this class. */
     private static Logger LOGGER = LoggerFactory.getLogger(ConsoleOperations.class);

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleRenderer.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleRenderer.java
@@ -43,12 +43,14 @@ import org.ff4j.property.PropertyShort;
 import org.ff4j.property.PropertyString;
 import org.ff4j.utils.Util;
 
+import static org.ff4j.web.embedded.ConsoleConstants.*;
+
 /**
  * Used to build GUI Interface for feature flip servlet. It contains gui component render and parmeters
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public final class ConsoleRenderer implements ConsoleConstants {
+public final class ConsoleRenderer {
 
     /** Cache for page blocks. */
     private static String htmlTemplate = null;

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
@@ -11,6 +11,7 @@ import static org.ff4j.web.embedded.ConsoleRenderer.renderMessageBox;
 import static org.ff4j.web.embedded.ConsoleRenderer.renderMsgGroup;
 import static org.ff4j.web.embedded.ConsoleRenderer.renderMsgProperty;
 import static org.ff4j.web.embedded.ConsoleRenderer.renderPage;
+import static org.ff4j.web.embedded.ConsoleConstants.*;
 
 /*
  * #%L AdministrationConsoleServlet.java (ff4j-web) by Cedrick LUNVEN %% Copyright (C) 2013 Ff4J %% Licensed under the Apache
@@ -49,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class ConsoleServlet extends HttpServlet implements ConsoleConstants {
+public class ConsoleServlet extends HttpServlet {
 
     /** serial number. */
     private static final long serialVersionUID = -3982043895954284269L;

--- a/ff4j-web/src/main/java/org/ff4j/web/taglib/AbstractFeatureTag.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/taglib/AbstractFeatureTag.java
@@ -27,14 +27,15 @@ import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.TagSupport;
 
 import org.ff4j.FF4j;
-import org.ff4j.web.embedded.ConsoleConstants;
+
+import static org.ff4j.web.embedded.ConsoleConstants.*;
 
 /**
  * Parent class for FF4J TagLib library.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public abstract class AbstractFeatureTag extends TagSupport implements ConsoleConstants {
+public abstract class AbstractFeatureTag extends TagSupport {
 
     /** serial number. */
     private static final long serialVersionUID = 3967425494402133171L;

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4jSecurityContextFilter.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4jSecurityContextFilter.java
@@ -29,7 +29,6 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 
 import org.ff4j.web.ApiConfig;
-import org.ff4j.web.FF4jWebConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,12 +38,14 @@ import com.sun.jersey.spi.container.ContainerRequestFilter;
 import com.sun.jersey.spi.container.ContainerResponseFilter;
 import com.sun.jersey.spi.container.ResourceFilter;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Filter to get security.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FF4jSecurityContextFilter implements FF4jWebConstants, ContainerRequestFilter, ResourceFilter {
+public class FF4jSecurityContextFilter implements ContainerRequestFilter, ResourceFilter {
 
     /** logger for this class. */
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/FeatureStoreHttp.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/FeatureStoreHttp.java
@@ -40,7 +40,6 @@ import org.ff4j.exception.FeatureNotFoundException;
 import org.ff4j.exception.GroupNotFoundException;
 import org.ff4j.store.AbstractFeatureStore;
 import org.ff4j.utils.Util;
-import org.ff4j.web.FF4jWebConstants;
 import org.ff4j.web.api.FF4jJacksonMapper;
 import org.ff4j.web.api.resources.domain.FeatureApiBean;
 import org.ff4j.web.api.resources.domain.GroupDescApiBean;
@@ -54,12 +53,14 @@ import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.json.JSONConfiguration;
 import com.sun.jersey.core.util.Base64;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Implementation of store using {@link HttpClient} connection.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureStoreHttp extends AbstractFeatureStore implements FF4jWebConstants {
+public class FeatureStoreHttp extends AbstractFeatureStore {
 
     private static final String OCCURED = " occured.";
 

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/PropertyStoreHttp.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/PropertyStoreHttp.java
@@ -37,7 +37,6 @@ import org.ff4j.property.Property;
 import org.ff4j.property.store.AbstractPropertyStore;
 import org.ff4j.utils.Util;
 import org.ff4j.utils.json.PropertyJsonParser;
-import org.ff4j.web.FF4jWebConstants;
 import org.ff4j.web.api.FF4jJacksonMapper;
 import org.ff4j.web.api.resources.domain.PropertyApiBean;
 
@@ -49,12 +48,14 @@ import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.json.JSONConfiguration;
 import com.sun.jersey.core.util.Base64;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Implementation of the store with REST.
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebConstants {
+public class PropertyStoreHttp extends AbstractPropertyStore {
 
     public static final String OCCURED = " occured.";
     /** Jersey Client. */

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/AbstractWebResourceTestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/AbstractWebResourceTestIT.java
@@ -44,12 +44,15 @@ import com.sun.jersey.test.framework.WebAppDescriptor;
 import com.sun.jersey.test.framework.spi.container.TestContainerFactory;
 import com.sun.jersey.test.framework.spi.container.grizzly2.web.GrizzlyWebTestContainerFactory;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Superclass for testing web resources.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public abstract class AbstractWebResourceTestIT extends JerseyTest implements TestsFf4jConstants, FF4jWebConstants {
+public abstract class AbstractWebResourceTestIT extends JerseyTest {
     
     /** Relative resource. */
     public final static String APIPATH = FF4jResource.class.getAnnotation(Path.class).value();

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FF4JResourceTestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FF4JResourceTestIT.java
@@ -31,6 +31,9 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.core.util.MultivaluedMapImpl;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Test core web resources /ff4j
  *

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_delete_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_delete_TestIT.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Integration test for resources {@link FeatureResource}.
  * 

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_get_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_get_TestIT.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Integration test for resources {@link FeatureResource}.
  * 

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_post_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_post_TestIT.java
@@ -29,6 +29,9 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Integration test for resources {@link FeatureResource}.
  * 

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putCreate_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putCreate_TestIT.java
@@ -31,6 +31,9 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateAuth1_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateAuth1_TestIT.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateAuth2_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateAuth2_TestIT.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateGroup1_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateGroup1_TestIT.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateGroup2_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/FeatureResource_putUpdateGroup2_TestIT.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/GroupResourceTestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/GroupResourceTestIT.java
@@ -14,6 +14,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /*
  * #%L
  * ff4j-web

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/PropertyResource_delete_TestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/PropertyResource_delete_TestIT.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.WebResource;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Integration test for resources {@link FeatureResource}.
  * 

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/SecuredFF4JResourceTestIT.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/resources/it/SecuredFF4JResourceTestIT.java
@@ -53,12 +53,14 @@ import com.sun.jersey.test.framework.WebAppDescriptor;
 import com.sun.jersey.test.framework.spi.container.TestContainerFactory;
 import com.sun.jersey.test.framework.spi.container.grizzly2.web.GrizzlyWebTestContainerFactory;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
 /**
  * Force security through API KEY and check.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class SecuredFF4JResourceTestIT extends JerseyTest implements TestsFf4jConstants, FF4jWebConstants {
+public class SecuredFF4JResourceTestIT extends JerseyTest {
     
     /** Relative resource. */
     public final static String APIPATH = FF4jResource.class.getAnnotation(Path.class).value();

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/store/FeatureStoreHttpSpringTest.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/store/FeatureStoreHttpSpringTest.java
@@ -34,6 +34,8 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.sun.jersey.test.framework.JerseyTest;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Unitary test for {@link FeatureStoreHttp} on Grizzly server.
  *

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/store/FeatureStoreHttpTest.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/store/FeatureStoreHttpTest.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 
 import com.sun.jersey.test.framework.JerseyTest;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Unitary test for {@link FeatureStoreHttp} on Grizzly server.
  *

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthenticationFilter.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthenticationFilter.java
@@ -33,17 +33,18 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 
 import org.ff4j.web.ApiConfig;
-import org.ff4j.web.FF4jWebConstants;
 import org.glassfish.jersey.internal.util.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.ff4j.web.FF4jWebConstants.*;
 
 /**
  * Filter to get security.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FF4jAuthenticationFilter implements ContainerRequestFilter, FF4jWebConstants {
+public class FF4jAuthenticationFilter implements ContainerRequestFilter {
 
     /** logger for this class. */
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
@@ -40,7 +40,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.Response.Status;
 
 import org.ff4j.web.ApiConfig;
-import org.ff4j.web.FF4jWebConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +48,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FF4jAuthorizationFilter implements ContainerRequestFilter, FF4jWebConstants {
+public class FF4jAuthorizationFilter implements ContainerRequestFilter {
 
     /** logger for this class. */
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/FeatureStoreHttp.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/FeatureStoreHttp.java
@@ -52,12 +52,14 @@ import org.glassfish.jersey.internal.util.Base64;
 
 import io.swagger.jaxrs.json.JacksonJsonProvider;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Implementation of store using {@link HttpClient} connection.
  * 
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public class FeatureStoreHttp extends AbstractFeatureStore implements org.ff4j.web.FF4jWebConstants {
+public class FeatureStoreHttp extends AbstractFeatureStore {
 
     /** Jersey Client. */
     protected Client client = null;

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/PropertyStoreHttp.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/PropertyStoreHttp.java
@@ -42,7 +42,6 @@ import org.ff4j.property.Property;
 import org.ff4j.property.store.AbstractPropertyStore;
 import org.ff4j.utils.Util;
 import org.ff4j.utils.json.PropertyJsonParser;
-import org.ff4j.web.FF4jWebConstants;
 import org.ff4j.web.api.FF4jJacksonMapper;
 import org.ff4j.web.api.resources.domain.PropertyApiBean;
 import org.glassfish.jersey.client.ClientConfig;
@@ -50,12 +49,14 @@ import org.glassfish.jersey.internal.util.Base64;
 
 import io.swagger.jaxrs.json.JacksonJsonProvider;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Implementation of the store with REST.
  *
  * @author Cedrick Lunven (@clunven)</a>
  */
-public class PropertyStoreHttp extends AbstractPropertyStore implements FF4jWebConstants {
+public class PropertyStoreHttp extends AbstractPropertyStore {
 
     public static final String OCCURED = " occured.";
     /** Jersey Client. */

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/AbstractWebResourceTestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/AbstractWebResourceTestIT.java
@@ -27,8 +27,6 @@ import javax.ws.rs.core.Application;
 
 import org.ff4j.FF4j;
 import org.ff4j.test.AssertFf4j;
-import org.ff4j.test.TestsFf4jConstants;
-import org.ff4j.web.FF4jWebConstants;
 import org.ff4j.web.api.FF4jJacksonMapper;
 import org.ff4j.web.api.resources.FF4jResource;
 import org.ff4j.web.api.test.SampleFF4jJersey2Application;
@@ -44,12 +42,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.jaxrs.json.JacksonJsonProvider;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Superclass for testing web resources.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public abstract class AbstractWebResourceTestIT extends JerseyTest implements TestsFf4jConstants, FF4jWebConstants {
+public abstract class AbstractWebResourceTestIT extends JerseyTest {
     
     /** Relative resource. */
     public final static String APIPATH = FF4jResource.class.getAnnotation(Path.class).value();

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FF4JResource2TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FF4JResource2TestIT.java
@@ -31,6 +31,9 @@ import org.ff4j.store.InMemoryFeatureStore;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Test core web resources /ff4j
  *

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_delete_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_delete_TestIT.java
@@ -29,6 +29,8 @@ import org.ff4j.web.api.resources.FeatureResource;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Integration test for resources {@link FeatureResource}.
  * 

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_get_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_get_TestIT.java
@@ -30,6 +30,8 @@ import org.ff4j.web.api.resources.domain.FeatureApiBean;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Integration test for resources {@link FeatureResource}.
  * 

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_post_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_post_TestIT.java
@@ -30,6 +30,9 @@ import org.ff4j.web.api.resources.FeatureResource;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Integration test for resources {@link FeatureResource}.
  * 

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putCreate_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putCreate_TestIT.java
@@ -32,6 +32,9 @@ import org.ff4j.web.api.resources.domain.FeatureApiBean;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateAuth1_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateAuth1_TestIT.java
@@ -32,6 +32,8 @@ import org.ff4j.web.api.resources.domain.FeatureApiBean;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateAuth2_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateAuth2_TestIT.java
@@ -32,6 +32,8 @@ import org.ff4j.web.api.resources.domain.FeatureApiBean;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateGroup1_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateGroup1_TestIT.java
@@ -32,6 +32,8 @@ import org.ff4j.web.api.resources.domain.FeatureApiBean;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateGroup2_TestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/FeatureResource2_putUpdateGroup2_TestIT.java
@@ -32,6 +32,8 @@ import org.ff4j.web.api.resources.domain.FeatureApiBean;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Externalisation of PUT REQUEST.
  *

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/GroupResourceTestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/GroupResourceTestIT.java
@@ -13,6 +13,8 @@ import org.ff4j.core.Feature;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /*
  * #%L
  * ff4j-web

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/SecuredFF4JResourceTestIT.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/it/SecuredFF4JResourceTestIT.java
@@ -48,6 +48,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.jaxrs.json.JacksonJsonProvider;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Force security through API KEY and check.
  *

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/store/FeatureStoreHttpTest.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/store/FeatureStoreHttpTest.java
@@ -30,6 +30,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.ff4j.test.TestsFf4jConstants.*;
+
 /**
  * Unitary test for {@link FeatureStoreHttp} on Grizzly server.
  *

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/AbstractResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/AbstractResource.java
@@ -29,14 +29,13 @@ import org.ff4j.FF4j;
 import org.ff4j.audit.repository.EventRepository;
 import org.ff4j.core.FeatureStore;
 import org.ff4j.property.store.PropertyStore;
-import org.ff4j.web.FF4jWebConstants;
 
 /**
  * SuperClass for common injections.
  *
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
-public abstract class AbstractResource implements FF4jWebConstants {
+public abstract class AbstractResource {
     
     /** Access to Features through store. */
     @Context

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FF4jResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FF4jResource.java
@@ -47,6 +47,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * This is the parent class for FF4J the REST API.
  * 

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureResource.java
@@ -53,6 +53,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Represent a feature as WebResource.
  * 

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureStoreResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureStoreResource.java
@@ -46,6 +46,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * WebResource representing the store.
  *

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/GroupResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/GroupResource.java
@@ -39,6 +39,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * WebResource representing a group of features.
  *

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/MonitoringResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/MonitoringResource.java
@@ -48,6 +48,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /**
  * Monitoring Resource.
  *

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/PropertyResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/PropertyResource.java
@@ -28,6 +28,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /*
  * #%L
  * ff4j-webapi

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/PropertyStoreResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/PropertyStoreResource.java
@@ -24,6 +24,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
+import static org.ff4j.web.FF4jWebConstants.*;
+
 /*
  * #%L
  * ff4j-webapi


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1214 - Constants should not be defined in interfaces.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1214
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava