### PR TITLE
Multiple code improvements - squid:S1444, squid:ClassVariableVisibilityCheck, squid:S2696, squid:S3008

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/utils/IOUtil.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/IOUtil.java
@@ -32,7 +32,7 @@ import java.net.UnknownHostException;
 public class IOUtil {
 
     /** Would like to use the Inet Component. */
-    public static boolean useInetAddress = true;
+    private static boolean useInetAddress = true;
     
     /**
      * Static
@@ -55,5 +55,13 @@ public class IOUtil {
         } catch (UnknownHostException e) {
             throw new IllegalArgumentException("Cannot find the target host by itself", e);
         }
+    }
+
+    public static boolean isUseInetAddress() {
+        return useInetAddress;
+    }
+
+    public static void setUseInetAddress(boolean useInetAddress) {
+        IOUtil.useInetAddress = useInetAddress;
     }
 }

--- a/ff4j-core/src/test/java/org/ff4j/test/utils/IOUtilsTest.java
+++ b/ff4j-core/src/test/java/org/ff4j/test/utils/IOUtilsTest.java
@@ -34,15 +34,15 @@ public class IOUtilsTest {
     
     @Test
     public void testResolveOK() throws Exception {
-        IOUtil.useInetAddress = true;
+        IOUtil.setUseInetAddress(true);
         IOUtil.resolveHostName();
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testResolveKO() throws Exception {
-        IOUtil.useInetAddress = false;
+        IOUtil.setUseInetAddress(false);
         IOUtil.resolveHostName();
-        IOUtil.useInetAddress = true;
+        IOUtil.setUseInetAddress(true);
         Assert.fail();
     }
 

--- a/ff4j-store-redis/src/main/java/org/ff4j/store/EventRepositoryRedis.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/store/EventRepositoryRedis.java
@@ -38,7 +38,7 @@ import redis.clients.jedis.Jedis;
 public class EventRepositoryRedis extends AbstractEventRepository {
 
 	/** prefix of keys. */
-    public static String KEY_EVENT = "FF4J_EVENT_";
+    public static final String KEY_EVENT = "FF4J_EVENT_";
     
     /** Default ttl. */
     private static int DEFAULT_TTL = 900000000;

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/FF4JApiApplication.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/FF4JApiApplication.java
@@ -70,9 +70,9 @@ public abstract class FF4JApiApplication extends PackagesResourceConfig {
         
         // Initialize through configuration
         ApiConfig conf = getApiConfig();
-        FF4jSecurityContextFilter.securityConfig = conf;
-        FF4jRolesResourceFilterFactory.apiConfig = conf;
-        
+        FF4jSecurityContextFilter.setSecurityConfig(conf);
+        FF4jRolesResourceFilterFactory.setApiConfig(conf);
+
         // Register ff4J bean to be injected into resources.
         getSingletons().add(new FF4jInjectableProvider(conf.getFF4j()));
         

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
@@ -67,8 +67,8 @@ public class FF4JSecurityContextAuthenticationManager extends AbstractAuthorizat
     @Override
     public Set<String> listAllPermissions() {
         Set < String > vars = new HashSet<String>();
-        if (FF4jSecurityContextFilter.securityConfig != null) {
-            Map < String, Set<String > > perms = FF4jSecurityContextFilter.securityConfig.getPermissions();
+        if (FF4jSecurityContextFilter.getSecurityConfig() != null) {
+            Map < String, Set<String > > perms = FF4jSecurityContextFilter.getSecurityConfig().getPermissions();
             for (Map.Entry<String,Set<String>> var : perms.entrySet()) {
                 var.getValue().addAll(var.getValue());
             }

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4jRolesResourceFilterFactory.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4jRolesResourceFilterFactory.java
@@ -37,7 +37,7 @@ import com.sun.jersey.spi.container.ResourceFilter;
 public class FF4jRolesResourceFilterFactory extends RolesAllowedResourceFilterFactory {
 
     /** Api Config to initialize filters. */
-    public static ApiConfig apiConfig = null;
+    private static ApiConfig apiConfig = null;
 
     /** {@inheritDoc} */
     @Override
@@ -57,5 +57,13 @@ public class FF4jRolesResourceFilterFactory extends RolesAllowedResourceFilterFa
         filters.add(0, new FF4jSecurityContextFilter());
 
         return filters;
+    }
+
+    public static ApiConfig getApiConfig() {
+        return apiConfig;
+    }
+
+    public static void setApiConfig(ApiConfig apiConfig) {
+        FF4jRolesResourceFilterFactory.apiConfig = apiConfig;
     }
 }

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4jSecurityContextFilter.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/api/security/FF4jSecurityContextFilter.java
@@ -51,7 +51,7 @@ public class FF4jSecurityContextFilter implements ContainerRequestFilter, Resour
     private final Logger log = LoggerFactory.getLogger(getClass());
     
     /** security configuration. */
-    public static ApiConfig securityConfig = null;
+    private static ApiConfig securityConfig = null;
 
     /**
      * Apply the filter : check input request, validate or not with user auth
@@ -146,5 +146,13 @@ public class FF4jSecurityContextFilter implements ContainerRequestFilter, Resour
     public ContainerResponseFilter getResponseFilter() {
         // No response filter
         return null;
+    }
+
+    public static ApiConfig getSecurityConfig() {
+        return securityConfig;
+    }
+
+    public static void setSecurityConfig(ApiConfig securityConfig) {
+        FF4jSecurityContextFilter.securityConfig = securityConfig;
     }
 }

--- a/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/api/test/filter/SecurityFilterTest.java
+++ b/ff4j-webapi-jersey1x/src/test/java/org/ff4j/web/api/test/filter/SecurityFilterTest.java
@@ -77,7 +77,7 @@ public class SecurityFilterTest {
         when(mockRequest.getMethod()).thenReturn("GET");
         when(mockRequest.getPath(true)).thenReturn("someURLl");
         when(mockRequest.getHeaderValue("Authorization")).thenReturn("apiKey=12");
-        FF4jSecurityContextFilter.securityConfig = new ApiConfig();
+        FF4jSecurityContextFilter.setSecurityConfig(new ApiConfig());
         Assert.assertNotNull(faf);
         faf.filter(mockRequest);
     }
@@ -96,7 +96,7 @@ public class SecurityFilterTest {
     @Test
     public void testAuthorizedApiKey() throws IOException {
         // Define ApiConfig
-        FF4jSecurityContextFilter.securityConfig = new ApiConfig().createApiKey("12", true, true, Util.set("USER"));
+        FF4jSecurityContextFilter.setSecurityConfig(new ApiConfig().createApiKey("12", true, true, Util.set("USER")));
         
         // Given
         FF4jSecurityContextFilter faf = new FF4jSecurityContextFilter();

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/FF4jApiApplicationJersey2x.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/FF4jApiApplicationJersey2x.java
@@ -131,13 +131,13 @@ public abstract class FF4jApiApplicationJersey2x extends ResourceConfig {
     }
     
     private void enableAuthenticationFilter() {
-        FF4jAuthenticationFilter.apiConfig = apiConfig;
+        FF4jAuthenticationFilter.setApiConfig(apiConfig);
         register(FF4jAuthenticationFilter.class);
         log.info("WebService Authentication is now enabled");
     }
     
     private void enableAuthorizationFilter() {
-        FF4jAuthorizationFilter.apiConfig = apiConfig;
+        FF4jAuthorizationFilter.setApiConfig(apiConfig);
         register(FF4jAuthorizationFilter.class);
         log.info("WebService Authorization is now enabled");
     }

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4JSecurityContextAuthenticationManager.java
@@ -64,8 +64,8 @@ public class FF4JSecurityContextAuthenticationManager extends AbstractAuthorizat
     /** {@inheritDoc} */
     public Set<String> listAllPermissions() {
         Set < String > vars = new HashSet<>();
-        if (FF4jAuthenticationFilter.apiConfig != null) {
-            Map < String, Set<String > > perms = FF4jAuthenticationFilter.apiConfig.getPermissions();
+        if (FF4jAuthenticationFilter.getApiConfig() != null) {
+            Map < String, Set<String > > perms = FF4jAuthenticationFilter.getApiConfig().getPermissions();
             for (Map.Entry<String,Set<String>> var : perms.entrySet()) {
                 perms.get(var.getKey()).addAll(var.getValue());
             }

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthenticationFilter.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthenticationFilter.java
@@ -50,7 +50,7 @@ public class FF4jAuthenticationFilter implements ContainerRequestFilter {
     private final Logger log = LoggerFactory.getLogger(getClass());
     
     /** security configuration. */
-    public static ApiConfig apiConfig = null;
+    private static ApiConfig apiConfig = null;
     
     /**
      * Apply the filter ozz: check input request, validate or not with user auth
@@ -132,5 +132,13 @@ public class FF4jAuthenticationFilter implements ContainerRequestFilter {
         log.error("Authentication error :" + message);
         throw new WebApplicationException(Response.status(Status.UNAUTHORIZED).entity(msg.toString())
                 .type(MediaType.TEXT_HTML_TYPE).build());
+    }
+
+    public static ApiConfig getApiConfig() {
+        return apiConfig;
+    }
+
+    public static void setApiConfig(ApiConfig apiConfig) {
+        FF4jAuthenticationFilter.apiConfig = apiConfig;
     }
 }

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthorizationFilter.java
@@ -54,7 +54,7 @@ public class FF4jAuthorizationFilter implements ContainerRequestFilter {
     private final Logger log = LoggerFactory.getLogger(getClass());
     
     /** security configuration. */
-    public static ApiConfig apiConfig = null;
+    private static ApiConfig apiConfig = null;
     
     @Context
     public ResourceInfo info;
@@ -163,7 +163,5 @@ public class FF4jAuthorizationFilter implements ContainerRequestFilter {
     public void setInfo(ResourceInfo info) {
         this.info = info;
     }
-    
-    
-    
+
 }

--- a/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/filter/SecurityAuthenticationFilterTest.java
+++ b/ff4j-webapi-jersey2x/src/test/java/org/ff4j/web/api/test/filter/SecurityAuthenticationFilterTest.java
@@ -88,7 +88,7 @@ public class SecurityAuthenticationFilterTest {
         when(mockUriInfo.getPath()).thenReturn("someURL");
         when(mockRequest.getUriInfo()).thenReturn(mockUriInfo);
         // Define ApiConfig
-        FF4jAuthenticationFilter.apiConfig = new ApiConfig();
+        FF4jAuthenticationFilter.setApiConfig(new ApiConfig());
         
         // When
         faf.filter(mockRequest);
@@ -112,7 +112,7 @@ public class SecurityAuthenticationFilterTest {
     @Test
     public void testAuthorizedApiKey() throws IOException {
         // Define ApiConfig
-        FF4jAuthenticationFilter.apiConfig = new ApiConfig().createApiKey("12", true, true, Util.set("USER"));
+        FF4jAuthenticationFilter.setApiConfig(new ApiConfig().createApiKey("12", true, true, Util.set("USER")));
         
         // Given
         FF4jAuthenticationFilter faf = new FF4jAuthenticationFilter();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1444 - "public static" fields should be constant.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S2696 - Instance methods should not write to "static" fields.
squid:S3008 - Static non-final field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2696
https://dev.eclipse.org/sonar/rules/show/squid:S3008
Please let me know if you have any questions.
George Kankava