### PR TITLE
squid:S106 - Standard outputs should not be used directly to log anything

### DIFF
--- a/ff4j-core/pom.xml
+++ b/ff4j-core/pom.xml
@@ -58,7 +58,12 @@
 			<artifactId>jackson-databind</artifactId>
 			<scope>test</scope>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
 
 	</dependencies>
 

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
@@ -31,6 +31,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.ff4j.audit.repository.EventRepository;
 import org.ff4j.audit.repository.InMemoryEventRepository;
+import org.ff4j.cache.FF4jCacheProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Default implementation of repository.
@@ -38,7 +41,10 @@ import org.ff4j.audit.repository.InMemoryEventRepository;
  * @author Cedrick Lunven (@clunven)
  */
 public class EventPublisher {
-    
+
+    /** Logger for the class. */
+    private static final Logger LOG = LoggerFactory.getLogger(EventPublisher.class);
+
     /** DEFAULT. */
     public static final int DEFAULT_QUEUE_CAPACITY = 100;
     
@@ -130,7 +136,7 @@ public class EventPublisher {
             final Future<Boolean> check = executor.submit(ew);
             check.get(submitTimeout, TimeUnit.MILLISECONDS);
         } catch (Exception e1) {
-            System.err.println("Cannot publish event " + e1.getMessage());
+            LOG.error("Cannot publish event " + e1.getMessage(), e1);
         }
     }
 

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
@@ -21,6 +21,9 @@ package org.ff4j.audit;
  */
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -30,6 +33,9 @@ import java.util.concurrent.ThreadPoolExecutor;
  * @author Cedrick Lunven (@clunven)</a>
  */
 public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
+
+    /** Logger for the class. */
+    private static final Logger LOG = LoggerFactory.getLogger(EventRejectedExecutionHandler.class);
 
     /** Simulate Interrupted. */
     private static boolean mock = false;
@@ -42,7 +48,7 @@ public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
             // try once again
             executor.execute(r);
         } catch (InterruptedException e) {
-            System.err.println("Event reject has been interrupted");
+            LOG.error("Event reject has been interrupted", e);
         }
     }
     

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthenticationFilter.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/api/security/FF4jAuthenticationFilter.java
@@ -22,6 +22,7 @@ import java.io.IOException;
  * #L%
  */
 
+import java.util.Arrays;
 import java.util.Set;
 
 import javax.ws.rs.WebApplicationException;
@@ -108,7 +109,7 @@ public class FF4jAuthenticationFilter implements ContainerRequestFilter {
             
             // Positionning Roles
             Set<String> perms = apiConfig.getPermissions().get(lap[0]);
-            System.out.println(perms);
+            log.info(Arrays.toString(perms.toArray()));
             SecurityContext sc = new FF4jSecurityContext(lap[0], FF4jSecurityContext.AUTH_SCHEME_BASIC, perms);
             containerRequest.setSecurityContext(sc);
             log.info("Client successfully logged with a user/pasword pair ");

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/FeatureStoreHttp.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/FeatureStoreHttp.java
@@ -51,6 +51,8 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.internal.util.Base64;
 
 import io.swagger.jaxrs.json.JacksonJsonProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.ff4j.web.FF4jWebConstants.*;
 
@@ -60,6 +62,9 @@ import static org.ff4j.web.FF4jWebConstants.*;
  * @author <a href="mailto:cedrick.lunven@gmail.com">Cedrick LUNVEN</a>
  */
 public class FeatureStoreHttp extends AbstractFeatureStore {
+
+    /** logger for this class. */
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     /** Jersey Client. */
     protected Client client = null;
@@ -159,7 +164,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
     public Feature read(String uid) {
         Util.assertHasLength(uid);
         Response cRes = getStore().path(uid).request(MediaType.APPLICATION_JSON_TYPE).get();
-        System.out.println(getStore().path(uid));
+        log.info(String.valueOf(getStore().path(uid)));
         if (Status.NOT_FOUND.getStatusCode() == cRes.getStatus()) {
             throw new FeatureNotFoundException(uid);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S106 - Standard outputs should not be used directly to log anything.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S106
Please let me know if you have any questions.
George Kankava