### PR TITLE
squid:S2864 -  entrySet() should be iterated when both the key and value are needed

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/Event.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/Event.java
@@ -114,9 +114,9 @@ public class Event implements Serializable {
         keyAsString(sb, "value", value);
         sb.append(", \"duration\":" + duration);
         if (customKeys != null && !customKeys.isEmpty()) {
-            for(String key : customKeys.keySet()) {
-                if (null != customKeys.get(key)) {
-                    keyAsString(sb, key, customKeys.get(key));
+            for(Map.Entry<String,String> customKeysEntry : customKeys.entrySet()) {
+                if (null != customKeysEntry.getValue()) {
+                    keyAsString(sb, customKeysEntry.getKey(), customKeysEntry.getValue());
                 }
             }
         }

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/InMemoryEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/InMemoryEventRepository.java
@@ -194,8 +194,8 @@ public class InMemoryEventRepository extends AbstractEventRepository {
         PieChart pieGraph = new PieChart("Hits Count for " + uid);
         List < String > colors = Util.getColorsGradient(freq.size());
         int idx = 0;
-        for (String action:freq.keySet()) {
-            pieGraph.getSectors().add(new PieSector(action, freq.get(action).get(), colors.get(idx)));
+        for (Map.Entry<java.lang.String, org.ff4j.audit.graph.MutableInt> actionEntry : freq.entrySet()) {
+            pieGraph.getSectors().add(new PieSector(actionEntry.getKey(), actionEntry.getValue().get(), colors.get(idx)));
             idx++;
         }
         return pieGraph;
@@ -212,13 +212,13 @@ public class InMemoryEventRepository extends AbstractEventRepository {
         
         if (eventsPerFeatures != null) {
             long slotWitdh = (endTime - startTime) / nbslot;
-            for (String name : eventsPerFeatures.keySet()) {
+            for (Map.Entry < String, Queue< Event > > nameEntry : eventsPerFeatures.entrySet()) {
                 
               // Retrieve events for target feature
-              Queue<Event> myQueue = eventsPerFeatures.get(name);
+              Queue<Event> myQueue = nameEntry.getValue();
               
               // Create series for this feature (even if not present)
-              BarSeries currentSeries = barChart.getSeries().get(name);
+              BarSeries currentSeries = barChart.getSeries().get(nameEntry.getKey());
               if (myQueue != null) {
                   for (Iterator<Event> itEvt = myQueue.iterator(); itEvt.hasNext();) {
                      Event evt = itEvt.next();
@@ -236,9 +236,9 @@ public class InMemoryEventRepository extends AbstractEventRepository {
     /** {@inheritDoc} */
     public int getTotalEventCount() {
         int total = 0;
-        for(String evt : events.keySet()) {
-            for(String name : events.get(evt).keySet()) {
-                total += events.get(evt).get(name).size();
+        for(Map.Entry<String, Map < String, Queue<Event> > > evtEntry : events.entrySet()) {
+            for(String name : evtEntry.getValue().keySet()) {
+                total += evtEntry.getValue().get(name).size();
             }
         }
         return total;

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
@@ -214,9 +214,9 @@ public class JdbcEventRepository extends AbstractEventRepository {
             }
             List < String > colors  = Util.getColorsGradient(freq.size());
             int idx = 0;
-            for (String featName : freq.keySet()) {
+            for (Map.Entry < String, Integer > featNameEntry : freq.entrySet()) {
                 pieGraph.getSectors().add(
-                        new PieSector(featName, freq.get(featName), colors.get(idx)));
+                        new PieSector(featNameEntry.getKey(), featNameEntry.getValue(), colors.get(idx)));
                 idx++;
             }
             
@@ -298,8 +298,8 @@ public class JdbcEventRepository extends AbstractEventRepository {
             }
             List < String > colors = Util.getColorsGradient(freq.size());
             int idx = 0;
-            for (String action : freq.keySet()) {
-                pieGraph.getSectors().add(new PieSector(action, freq.get(action), colors.get(idx)));
+            for (Map.Entry < String, Integer > actionEntry : freq.entrySet()) {
+                pieGraph.getSectors().add(new PieSector(actionEntry.getKey(), actionEntry.getValue(), colors.get(idx)));
                 idx++;
             }
             return pieGraph;

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/FeatureStoreNeo4J.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/store/FeatureStoreNeo4J.java
@@ -337,11 +337,11 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore {
         Map < String, String > initParams = fp.getFlippingStrategy().getInitParams();
         if (initParams != null && initParams.size() > 0) {
             boolean first = true;
-            for (String key : initParams.keySet()) {
+            for (Map.Entry < String, String > entry : initParams.entrySet()) {
                 if (!first) {
                     fsCreateQuery += ",";
                 }
-                fsCreateQuery += "'" + key + "=" + initParams.get(key) + "'";
+                fsCreateQuery += "'" + entry.getKey() + "=" + entry.getValue() + "'";
                 first = false;
             }
         }
@@ -414,11 +414,11 @@ public class FeatureStoreNeo4J extends AbstractFeatureStore {
         Map < String, String > initParams = fp.getFlippingStrategy().getInitParams();
             if (initParams != null && initParams.size() > 0) {
             boolean first = true;
-            for (String key : initParams.keySet()) {
+            for (Map.Entry < String, String > entry : initParams.entrySet()) {
                 if (!first) {
                     queryUpdate += ",";
                 }
-                queryUpdate += "'" + key + "=" + initParams.get(key) + "'";
+                queryUpdate += "'" + entry.getKey() + "=" + entry.getValue() + "'";
                 first = false;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
George Kankava.