### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/ff4j-cli/src/main/java/org/ff4j/cli/MainCli.java
+++ b/ff4j-cli/src/main/java/org/ff4j/cli/MainCli.java
@@ -34,7 +34,9 @@ import java.io.InputStreamReader;
  * @author Cedrick Lunven (@clunven)</a>
  */
 public class MainCli {
-	
+
+	private MainCli() {}
+
 	/**
 	 * Main loop.
 	 *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 60 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava