### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
+++ b/ff4j-aop/src/main/java/org/ff4j/aop/FeatureAdvisor.java
@@ -46,6 +46,10 @@ import org.springframework.stereotype.Service;
 @Component("ff.advisor")
 public class FeatureAdvisor implements MethodInterceptor, BeanPostProcessor, ApplicationContextAware {
 
+    /** String constants */
+    private static final String FF4J_AOP_CANNOT_INVOKE = "ff4j-aop: Cannot invoke ";
+    private static final String ON_ALTERBEAN = " on alterbean ";
+
     /** Log with target className. */
     private final Map<String, Logger> targetLoggers = new HashMap<String, Logger>();
 
@@ -323,16 +327,16 @@ public class FeatureAdvisor implements MethodInterceptor, BeanPostProcessor, App
         try {
             return method.invoke(targetBean, pMInvoc.getArguments());
         } catch (IllegalAccessException e) {
-            throw makeIllegalArgumentException("ff4j-aop: Cannot invoke " + method.getName() + " on alterbean " + declaringClass
+            throw makeIllegalArgumentException(FF4J_AOP_CANNOT_INVOKE + method.getName() + ON_ALTERBEAN + declaringClass
                     + " please check visibility", e);
         } catch (InvocationTargetException invocationTargetException) {
             if(!ff4j.isAlterBeanThrowInvocationTargetException() && invocationTargetException.getCause() != null) {
                 throw invocationTargetException.getCause();
             }
-            throw makeIllegalArgumentException("ff4j-aop: Cannot invoke " + method.getName() + " on alterbean " + declaringClass
+            throw makeIllegalArgumentException(FF4J_AOP_CANNOT_INVOKE + method.getName() + ON_ALTERBEAN + declaringClass
                     + " please check signatures", invocationTargetException);
         } catch (Exception exception) {
-            throw makeIllegalArgumentException("ff4j-aop: Cannot invoke " + method.getName() + " on alterbean " + declaringClass
+            throw makeIllegalArgumentException(FF4J_AOP_CANNOT_INVOKE + method.getName() + ON_ALTERBEAN + declaringClass
                     + " please check signatures", exception);
         }
     }

--- a/ff4j-cli/src/main/java/org/ff4j/cli/FF4jCliOptions.java
+++ b/ff4j-cli/src/main/java/org/ff4j/cli/FF4jCliOptions.java
@@ -29,8 +29,13 @@ import org.apache.commons.cli.Options;
  * @author Cedrick LUNVEN (@clunven)
  */
 public class FF4jCliOptions {
-	
-	/**
+
+    /** String constants */
+    private static final String FEATURE = "feature";
+    private static final String FEATURENAME = "featurename";
+    private static final String TARGET_FEATURE_TO_UPDATE = "target feature to update";
+
+    /**
 	 * Remove public constructor for utilities.
 	 */
 	private FF4jCliOptions() {
@@ -63,10 +68,10 @@ public class FF4jCliOptions {
      */
     public static Options enableFeatureOptions() {
     	 Options options = new Options();
-         options.addOption(Option.builder("f").longOpt("feature")
-                 .hasArg().argName("featurename")
+         options.addOption(Option.builder("f").longOpt(FEATURE)
+                 .hasArg().argName(FEATURENAME)
                  .required(true)
-                 .desc("target feature to update").build());
+                 .desc(TARGET_FEATURE_TO_UPDATE).build());
          return options;
     }
     
@@ -94,10 +99,10 @@ public class FF4jCliOptions {
     public static Options grantOptions() {
     	 Options options = new Options();
     	 
-    	 options.addOption(Option.builder("f").longOpt("feature")
-                 .hasArg().argName("featurename")
+    	 options.addOption(Option.builder("f").longOpt(FEATURE)
+                 .hasArg().argName(FEATURENAME)
                  .required(true)
-                 .desc("target feature to update").build());
+                 .desc(TARGET_FEATURE_TO_UPDATE).build());
     	 
     	 options.addOption(Option.builder("r").longOpt("role")
                  .hasArg().argName("roleName")
@@ -114,10 +119,10 @@ public class FF4jCliOptions {
      */
     public static Options addGroupOptions() {
     	 Options options = new Options();
-    	 options.addOption(Option.builder("f").longOpt("feature")
-                 .hasArg().argName("featurename")
+    	 options.addOption(Option.builder("f").longOpt(FEATURE)
+                 .hasArg().argName(FEATURENAME)
                  .required(true)
-                 .desc("target feature to update").build());
+                 .desc(TARGET_FEATURE_TO_UPDATE).build());
          options.addOption(Option.builder("g").longOpt("group")
                  .hasArg().argName("groupName")
                  .required(true)

--- a/ff4j-cli/src/main/java/org/ff4j/cli/FF4jCliProcessor.java
+++ b/ff4j-cli/src/main/java/org/ff4j/cli/FF4jCliProcessor.java
@@ -64,7 +64,11 @@ public class FF4jCliProcessor {
 
 	/** Commons-cli command parser. */
 	private static final CommandLineParser CMD_PARSER = new DefaultParser();
-	
+
+	/** String constants */
+	private static final String FEATURE = "Feature ";
+	private static final String ERROR_DURING_CONNECT_COMMAND = "Error during connect command";
+
 	/** Environnements. */
 	private Map<String, FF4j> envs = new LinkedHashMap<String, FF4j>();
 
@@ -248,12 +252,12 @@ public class FF4jCliProcessor {
 				} else {
 					if (cmd.getArgList().get(0).equals("addToGroup")) {
 						currentFF4J.getFeatureStore().addToGroup(feature, group);
-						logInfo("Feature " + feature + " has been added to group " + group);
+						logInfo(FEATURE + feature + " has been added to group " + group);
 					} else if (cmd.getArgList().get(0).equals("removeFromGroup")) {
 						String currentGroup = currentFF4J.getFeatureStore().read(feature).getGroup();
 						if (group.equals(currentGroup)) {
 							currentFF4J.getFeatureStore().removeFromGroup(feature, group);
-							logInfo("Feature " + feature + " has been removed from group: " + group);
+							logInfo(FEATURE + feature + " has been removed from group: " + group);
 						} else if (currentGroup == null || currentGroup.isEmpty()){
 							logWarn("The groupName is invalid expected:" + currentGroup + " but was [" + group + "]");
 						} else {
@@ -287,7 +291,7 @@ public class FF4jCliProcessor {
 							logWarn("The role is invalidn there is no role on the feature " + feature);
 						} else if (permissions.contains(role)) {
 							currentFF4J.getFeatureStore().removeRoleFromFeature(feature, role);
-							logInfo("Feature " + feature + " has not more role " + role);
+							logInfo(FEATURE + feature + " has not more role " + role);
 						} else {
 							logWarn("The role is invalid expected one of " + permissions.toString());
 						}
@@ -326,7 +330,7 @@ public class FF4jCliProcessor {
 				}
 			}
 		} catch (ParseException e) {
-			error(e, "Error during connect command");
+			error(e, ERROR_DURING_CONNECT_COMMAND);
 		}
 	}
 	
@@ -350,15 +354,15 @@ public class FF4jCliProcessor {
 					
 				} else if (enable){
 					currentFF4J.getFeatureStore().enable(featureName);
-					logInfo("Feature " + featureName + " is now enabled") ;
+					logInfo(FEATURE + featureName + " is now enabled") ;
 					
 				} else {
 					currentFF4J.getFeatureStore().disable(featureName);
-					logInfo("Feature " + featureName + " is now disabled") ;
+					logInfo(FEATURE + featureName + " is now disabled") ;
 				}
 			}
 		} catch (ParseException moe) {
-			error(moe, "Error during connect command");
+			error(moe, ERROR_DURING_CONNECT_COMMAND);
 		}
 	}
 	
@@ -394,7 +398,7 @@ public class FF4jCliProcessor {
 				}
 			}
 		} catch (ParseException e) {
-			error(e, "Error during connect command");
+			error(e, ERROR_DURING_CONNECT_COMMAND);
 		}
 	}
 	

--- a/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/embedded/ConsoleServlet.java
@@ -87,8 +87,9 @@ public class ConsoleServlet extends FF4jInitServlet {
     public static final Logger LOGGER = LoggerFactory.getLogger(ConsoleServlet.class);
     
     /** Error Message. */
-    public static final String ERROR = "error";
-    
+    private static final String ERROR = "error";
+    private static final String AN_ERROR_OCCURED = "An error occured ";
+
 
     /** {@inheritDoc} */
     public void doGet(HttpServletRequest req, HttpServletResponse res)
@@ -146,7 +147,7 @@ public class ConsoleServlet extends FF4jInitServlet {
             // Any Error is trapped and display in the console
             messagetype = ERROR;
             message = e.getMessage();
-            LOGGER.error("An error occured ", e);
+            LOGGER.error(AN_ERROR_OCCURED, e);
         }
         renderPageMonitoring(getFf4j(), req, res, message, messagetype);
     }
@@ -248,7 +249,7 @@ public class ConsoleServlet extends FF4jInitServlet {
             // Any Error is trapped and display in the console
             messagetype = ERROR;
             message = e.getMessage();
-            LOGGER.error("An error occured ", e);
+            LOGGER.error(AN_ERROR_OCCURED, e);
         }
 
         // Default page rendering (table)
@@ -333,7 +334,7 @@ public class ConsoleServlet extends FF4jInitServlet {
         } catch (Exception e) {
             messagetype = ERROR;
             message = e.getMessage();
-            LOGGER.error("An error occured ", e);
+            LOGGER.error(AN_ERROR_OCCURED, e);
         }
         renderPage(ff4j, req, res, message, messagetype);
     }

--- a/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/FeatureStoreHttp.java
+++ b/ff4j-webapi-jersey2x/src/main/java/org/ff4j/web/jersey2/store/FeatureStoreHttp.java
@@ -66,6 +66,10 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
     /** logger for this class. */
     private final Logger log = LoggerFactory.getLogger(getClass());
 
+    /** String constants */
+    private static final String OCCURED = " occured.";
+    private static final String CANNOT_GRANT_ROLE_ON_FEATURE_AN_HTTP_ERROR = "Cannot grant role on feature, an HTTP error ";
+
     /** Jersey Client. */
     protected Client client = null;
 
@@ -220,7 +224,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
                 .put(Entity.entity(new FeatureApiBean(fp), MediaType.APPLICATION_JSON));
         // Check response code CREATED or raised error
         if (Status.CREATED.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot create feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot create feature, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -230,7 +234,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
         
         Response cRes = getStore().request(MediaType.APPLICATION_JSON_TYPE).get();
         if (Status.OK.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot read features, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot read features, an HTTP error " + cRes.getStatus() + OCCURED);
         }
        
         String resEntity = (String) cRes.readEntity(String.class);
@@ -251,7 +255,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
             throw new FeatureNotFoundException(uid);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot delete feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot delete feature, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -268,7 +272,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
                 .request(MediaType.APPLICATION_JSON)
                 .put(Entity.entity(new FeatureApiBean(fp), MediaType.APPLICATION_JSON));
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot update feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot update feature, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -281,7 +285,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
             throw new FeatureNotFoundException(uid);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot grant role on feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException(CANNOT_GRANT_ROLE_ON_FEATURE_AN_HTTP_ERROR + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -294,7 +298,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
             throw new FeatureNotFoundException(uid);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot remove role on feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot remove role on feature, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -310,7 +314,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
         }
         
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot add feature to group, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot add feature to group, an HTTP error " + cRes.getStatus() + OCCURED);
         }
         
     }
@@ -327,7 +331,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
             throw new GroupNotFoundException(groupName);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot remove feature from group, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot remove feature from group, an HTTP error " + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -340,7 +344,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
             throw new GroupNotFoundException(groupName);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot grant role on feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException(CANNOT_GRANT_ROLE_ON_FEATURE_AN_HTTP_ERROR + cRes.getStatus() + OCCURED);
         }
     }
 
@@ -354,7 +358,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
             throw new GroupNotFoundException(groupName);
         }
         if (Status.NO_CONTENT.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot grant role on feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException(CANNOT_GRANT_ROLE_ON_FEATURE_AN_HTTP_ERROR + cRes.getStatus() + OCCURED);
         }
     }
    
@@ -367,7 +371,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
             throw new GroupNotFoundException(groupName);
         }
         if (Status.OK.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot grant role on feature, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException(CANNOT_GRANT_ROLE_ON_FEATURE_AN_HTTP_ERROR + cRes.getStatus() + OCCURED);
         }
         String resEntity = cRes.readEntity(String.class);
         Feature[] fArray = parseFeatureArray(resEntity);
@@ -389,7 +393,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
         if (Status.NOT_FOUND.getStatusCode() == cRes.getStatus()) {
             return false;
         }
-        throw new FeatureAccessException("Cannot check existence of group , an HTTP error " + cRes.getStatus() + " occured.");
+        throw new FeatureAccessException("Cannot check existence of group , an HTTP error " + cRes.getStatus() + OCCURED);
     }
 
     /** {@inheritDoc} */
@@ -399,7 +403,7 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
         Response cRes = getGroups().request(MediaType.APPLICATION_JSON).get();
         List < Map < String, String>> groupList = cRes.readEntity(List.class);
         if (Status.OK.getStatusCode() != cRes.getStatus()) {
-            throw new FeatureAccessException("Cannot read groups, an HTTP error " + cRes.getStatus() + " occured.");
+            throw new FeatureAccessException("Cannot read groups, an HTTP error " + cRes.getStatus() + OCCURED);
         }
         Set < String > groupNames = new HashSet<>();
         for (Map <String, String > currentGroup : groupList) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 - String literals should not be duplicated.
This pull request removes 106 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava