### PR TITLE
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -173,12 +173,12 @@ public class FF4j {
 
         // If authorization manager provided, apply security filter
         if (flipped && getAuthorizationsManager() != null) {
-            flipped = flipped && isAllowed(fp);
+            flipped = isAllowed(fp);
         }
 
         // If custom strategy has been defined, delegate flipping to
         if (flipped && fp.getFlippingStrategy() != null) {
-            flipped = flipped && fp.getFlippingStrategy().evaluate(featureID, getFeatureStore(), executionContext);
+            flipped = fp.getFlippingStrategy().evaluate(featureID, getFeatureStore(), executionContext);
         }
         // Update current context
         currentExecutionContext.set(executionContext);

--- a/ff4j-core/src/main/java/org/ff4j/strategy/el/ExpressionNode.java
+++ b/ff4j-core/src/main/java/org/ff4j/strategy/el/ExpressionNode.java
@@ -114,7 +114,7 @@ public class ExpressionNode {
         boolean status = true;
         int idx = 0;
         while (status && idx < subNodes.size()) {
-            status = status && subNodes.get(idx).evalue(stateMap);
+            status = subNodes.get(idx).evalue(stateMap);
             idx++;
         }
         return status;

--- a/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/FeatureStoreHttp.java
+++ b/ff4j-webapi-jersey1x/src/main/java/org/ff4j/web/jersey1/store/FeatureStoreHttp.java
@@ -323,12 +323,6 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
         if (roleName == null || roleName.isEmpty()) {
             throw new IllegalArgumentException(ROLE_NAME_CANNOT_BE_NULL_NOR_EMPTY);
         }
-        if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
-        }
-        if (roleName == null || roleName.isEmpty()) {
-            throw new IllegalArgumentException(ROLE_NAME_CANNOT_BE_NULL_NOR_EMPTY);
-        }
         ClientResponse cRes = getStore().path(uid).path(OPERATION_REMOVEROLE).path(roleName).post(ClientResponse.class);
         if (Status.NOT_FOUND.getStatusCode() == cRes.getStatus()) {
             throw new FeatureNotFoundException(uid);
@@ -359,12 +353,6 @@ public class FeatureStoreHttp extends AbstractFeatureStore {
     /** {@inheritDoc} */
     @Override
     public void removeFromGroup(String uid, String groupName) {
-        if (uid == null || uid.isEmpty()) {
-            throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
-        }
-        if (groupName == null || groupName.isEmpty()) {
-            throw new IllegalArgumentException(GROUPNAME_CANNOT_BE_NULL_NOR_EMPTY);
-        }
         if (uid == null || uid.isEmpty()) {
             throw new IllegalArgumentException(FEATURE_IDENTIFIER_CANNOT_BE_NULL_NOR_EMPTY);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
This pull request removes 70 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2583
Please let me know if you have any questions.
George Kankava