### PR TITLE
squid:S1166 - Exception handlers should preserve the original exception

### DIFF
--- a/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/FF4jPropertiesPlaceHolderConfigurer.java
+++ b/ff4j-aop/src/main/java/org/ff4j/spring/placeholder/FF4jPropertiesPlaceHolderConfigurer.java
@@ -77,7 +77,7 @@ public class FF4jPropertiesPlaceHolderConfigurer implements BeanFactoryPostProce
                 try {
                     visitor.visitBeanDefinition(bd);
                 } catch (BeanDefinitionStoreException ex) {
-                    throw new BeanDefinitionStoreException(bd.getResourceDescription(), beanNames[i], ex.getMessage());
+                    throw new BeanDefinitionStoreException(bd.getResourceDescription(), beanNames[i], ex.getMessage(), ex);
                 }
             }
         } catch (Exception e) {

--- a/ff4j-store-jcache/src/main/java/org/ff4j/cache/FF4jJCacheProvider.java
+++ b/ff4j-store-jcache/src/main/java/org/ff4j/cache/FF4jJCacheProvider.java
@@ -28,9 +28,13 @@ import javax.cache.spi.CachingProvider;
 
 import org.ff4j.core.Feature;
 import org.ff4j.property.Property;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FF4jJCacheProvider {
-    
+
+    private static final Logger logger = LoggerFactory.getLogger(FF4jJCacheProvider.class);
+
     /** The Cache Provider. */
     private CachingProvider cachingProvider;
     
@@ -71,6 +75,7 @@ public class FF4jJCacheProvider {
             }
             return Caching.getCachingProvider(cachingProviderClassname);
         } catch(RuntimeException re) {
+            logger.error(re.getMessage(), re);
             /* Some cache implementation do not provide CachingProvider but the cacheManager
              * work properly. As a consequence, caching provider can be null and should not throw
              * caching exception.

--- a/ff4j-web/src/main/java/org/ff4j/web/console/ImageProvider.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/console/ImageProvider.java
@@ -98,7 +98,9 @@ public class ImageProvider {
 		} finally {
 			try {
 				bos.close();
-			} catch (IOException e) {}
+			} catch (IOException e) {
+				LOGGER.error(e.getMessage(), e);
+			}
 		}
 	}	
 	

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FF4jResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FF4jResource.java
@@ -46,6 +46,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.ff4j.web.FF4jWebConstants.*;
 
@@ -59,7 +61,9 @@ import static org.ff4j.web.FF4jWebConstants.*;
 @RolesAllowed({FF4jWebConstants.ROLE_READ})
 @Api(value = "/ff4j")
 public class FF4jResource extends AbstractResource {
-    
+
+    private static final Logger logger = LoggerFactory.getLogger(FF4jResource.class);
+
     /**
      * Provide core information on ff4J and available sub resources.
      * @return
@@ -158,6 +162,7 @@ public class FF4jResource extends AbstractResource {
            boolean flipped = ff4j.check(uid, flipExecCtx);
            return Response.ok(String.valueOf(flipped)).build();
        } catch(IllegalArgumentException iae) {
+           logger.error(iae.getMessage(), iae);
            String errMsg = "Invalid parameter " + iae.getMessage();
            return Response.status(Response.Status.BAD_REQUEST).entity(errMsg).build();
        }

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/FeatureResource.java
@@ -52,6 +52,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.ff4j.web.FF4jWebConstants.*;
 
@@ -65,7 +67,9 @@ import static org.ff4j.web.FF4jWebConstants.*;
 @RolesAllowed({FF4jWebConstants.ROLE_WRITE})
 @Api(value = "/ff4j/store/features/{uid}")
 public class FeatureResource extends AbstractResource {
-  
+
+    private static final Logger logger = LoggerFactory.getLogger(FeatureResource.class);
+
     /**
      * Allows to retrieve feature by its id.
      * 
@@ -124,6 +128,7 @@ public class FeatureResource extends AbstractResource {
                 Map<String, String> initparams = flipApiBean.getInitParams();
                 feat.setFlippingStrategy(MappingUtil.instanceFlippingStrategy(id, flipApiBean.getType(), initparams));
             } catch (Exception e) {
+                logger.error(e.getMessage(), e);
                 String errMsg = "Cannot read Flipping Strategy, does not seems to have a DEFAULT constructor, " + e.getMessage();
                 return Response.status(Response.Status.BAD_REQUEST).entity(errMsg).build();
             }
@@ -143,6 +148,7 @@ public class FeatureResource extends AbstractResource {
             try {
                 return Response.created(new URI(location)).build();
             } catch (URISyntaxException e) {
+                logger.error(e.getMessage(), e);
                 return Response.status(Response.Status.CREATED).header(LOCATION, location).entity(id).build();
             }
         }

--- a/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/PropertyResource.java
+++ b/ff4j-webapi/src/main/java/org/ff4j/web/api/resources/PropertyResource.java
@@ -27,6 +27,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.ff4j.web.FF4jWebConstants.*;
 
@@ -60,7 +62,9 @@ import static org.ff4j.web.FF4jWebConstants.*;
 @RolesAllowed({FF4jWebConstants.ROLE_WRITE})
 @Api(value = "/ff4j/propertyStore/properties/{name}")
 public class PropertyResource extends AbstractResource {
- 
+
+    private static final Logger logger = LoggerFactory.getLogger(PropertyResource.class);
+
     /**
      * Allows to retrieve feature by its id.
      * 
@@ -115,6 +119,7 @@ public class PropertyResource extends AbstractResource {
             try {
                 return Response.created(new URI(location)).build();
             } catch (URISyntaxException e) {
+                logger.error(e.getMessage(), e);
                 return Response.status(Response.Status.CREATED).header(LOCATION, location).entity(name).build();
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1166 - Exception handlers should preserve the original exception.
This pull request removes 60 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1166
Please let me know if you have any questions.
George Kankava