### PR TITLE
Multiple code improvements - squid:MethodCyclomaticComplexity, squid:S00115, squid:S2142, squid:S1161

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventPublisher.java
@@ -51,7 +51,7 @@ public class EventPublisher {
     public static final int DEFAULT_POOL_SIZE = 4;
     
     /** 2s to save the event other wize skip. */
-    public static final long timeout = 2000L;
+    public static final long TIMEOUT = 2000L;
     
     /** Executor for item writer. */
     private ExecutorService executor;
@@ -83,7 +83,7 @@ public class EventPublisher {
      * Default constructor.
      */
     public EventPublisher(int queueCapacity, int poolSize, EventRepository er) {
-        this(queueCapacity, poolSize, er, timeout);
+        this(queueCapacity, poolSize, er, TIMEOUT);
     }
 
     /**
@@ -108,7 +108,7 @@ public class EventPublisher {
      * @param executorService the executor service
      */
     public EventPublisher(EventRepository er, ExecutorService executorService) {
-        this(er, executorService, timeout);
+        this(er, executorService, TIMEOUT);
     }
 
     /**

--- a/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/EventRejectedExecutionHandler.java
@@ -48,6 +48,7 @@ public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
             // try once again
             executor.execute(r);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             LOG.error("Event reject has been interrupted", e);
         }
     }
@@ -61,8 +62,10 @@ public class EventRejectedExecutionHandler implements RejectedExecutionHandler {
      *      interupted
      */
     public void waitInSeconds(int nbSecond) throws InterruptedException {
-        if (mock) throw new InterruptedException();
-        Thread.sleep(1000 * nbSecond);
+        if (mock) {
+            throw new InterruptedException();
+        }
+        Thread.sleep(1000L * nbSecond);
     }
 
     public static boolean isMock() {

--- a/ff4j-core/src/main/java/org/ff4j/audit/PublisherThreadFactory.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/PublisherThreadFactory.java
@@ -52,6 +52,7 @@ public class PublisherThreadFactory implements ThreadFactory {
     }
 
     /** {@inheritDoc} */
+    @Override
     public Thread newThread(Runnable r) {
         Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
         t.setDaemon(false);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:MethodCyclomaticComplexity - Methods should not be too complex.
squid:S00115 - Constant names should comply with a naming convention.
squid:S2142 - "InterruptedException" should not be ignored.
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
This pull request removes 57 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:MethodCyclomaticComplexity
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S1161
Please let me know if you have any questions.
George Kankava