### PR TITLE
Multiple code improvements - squid:S1161, squid:S1186, squid:S00122, squid:S1170

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/FF4j.java
+++ b/ff4j-core/src/main/java/org/ff4j/FF4j.java
@@ -89,7 +89,7 @@ public class FF4j {
     private final String version = getClass().getPackage().getImplementationVersion();
     
     /** Source of initialization (JAVA_API, WEBAPI, SSH, CONSOLE...). */
-    private final String source =  SOURCE_JAVA;
+    private static final String source =  SOURCE_JAVA;
     
     /** Storage to persist feature within {@link FeatureStore}. */
     private FeatureStore fstore = new InMemoryFeatureStore();
@@ -543,6 +543,7 @@ public class FF4j {
     }
 
     /** {@inheritDoc} */
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("{");
         long uptime = System.currentTimeMillis() - startTime;
@@ -697,7 +698,9 @@ public class FF4j {
      * @return current store
      */
     public FeatureStore getFeatureStore() {
-        if (!initialized) init();
+        if (!initialized) {
+            init();
+        }
         return fstore;
     }
     
@@ -708,7 +711,9 @@ public class FF4j {
      * @return current value of 'eventPublisher'
      */
     public synchronized EventPublisher getEventPublisher() {
-        if (!initialized) init();
+        if (!initialized) {
+            init();
+        }
         return eventPublisher;
     }
     
@@ -719,7 +724,8 @@ public class FF4j {
      *       current value of 'pStore'
      */
     public PropertyStore getPropertiesStore() {
-        if (!initialized) init();
+        if (!initialized) 
+            init();
         return pStore;
     }
     
@@ -730,7 +736,8 @@ public class FF4j {
      *      get current context
      */
     public FlippingExecutionContext getCurrentContext() {
-        if (!initialized) init();
+        if (!initialized) 
+            init();
         
         if (null == this.currentExecutionContext.get()) {
             this.currentExecutionContext.set(new FlippingExecutionContext());
@@ -812,8 +819,8 @@ public class FF4j {
      * @param fname
      *      target name
      */
-    public void setFileName(String fname) { }
-    public void setAuthManager(String mnger) { }
+    public void setFileName(String fname) { /** empty setter for Spring framework */ }
+    public void setAuthManager(String mnger) { /** empty setter for Spring framework */ }
 
     /**
      * Shuts down the event publisher if we actually started it (As opposed to

--- a/ff4j-core/src/main/java/org/ff4j/audit/proxy/FeatureStoreAuditProxy.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/proxy/FeatureStoreAuditProxy.java
@@ -63,6 +63,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
     
     /** {@inheritDoc} */
+    @Override
     public void enable(String uid) {
         long start = System.nanoTime();
         target.enable(uid);
@@ -71,6 +72,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void disable(String uid) {
         long start = System.nanoTime();
         target.disable(uid);
@@ -79,6 +81,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }    
 
     /** {@inheritDoc} */
+    @Override
     public void create(Feature fp) {
         long start = System.nanoTime();
         target.create(fp);
@@ -87,6 +90,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void delete(String uid) {
         long start = System.nanoTime();
         target.delete(uid);
@@ -95,6 +99,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void update(Feature fp) {
         long start = System.nanoTime();
         target.update(fp);
@@ -103,6 +108,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void grantRoleOnFeature(String uid, String roleName) {
         long start = System.nanoTime();
         target.grantRoleOnFeature(uid, roleName);
@@ -119,6 +125,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
     
     /** {@inheritDoc} */
+    @Override
     public void enableGroup(String groupName) {
         long start = System.nanoTime();
         target.enableGroup(groupName);
@@ -127,6 +134,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void disableGroup(String groupName) {
         long start = System.nanoTime();
         target.disableGroup(groupName);
@@ -135,6 +143,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void addToGroup(String uid, String groupName) {
         long start = System.nanoTime();
         target.addToGroup(uid, groupName);
@@ -143,6 +152,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void removeFromGroup(String uid, String groupName) {
         long start = System.nanoTime();
         target.removeFromGroup(uid, groupName);
@@ -151,6 +161,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void clear() {
         long start = System.nanoTime();
         target.clear();
@@ -182,36 +193,43 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
     
     /** {@inheritDoc} */
+    @Override
     public boolean exist(String uid) {
         return target.exist(uid);
     }
 
     /** {@inheritDoc} */
+    @Override
     public Feature read(String uid) {
         return target.read(uid);
     }
 
     /** {@inheritDoc} */
+    @Override
     public Map<String, Feature> readAll() {
         return target.readAll();
     }
 
     /** {@inheritDoc} */
+    @Override
     public boolean existGroup(String groupName) {
         return target.existGroup(groupName);
     }
 
     /** {@inheritDoc} */
+    @Override
     public Map<String, Feature> readGroup(String groupName) {
         return target.readGroup(groupName);
     }
 
     /** {@inheritDoc} */
+    @Override
     public Set<String> readAllGroups() {
         return target.readAllGroups();
     }
     
     /** {@inheritDoc} */
+    @Override
     public void importFeatures(Collection<Feature> features) {
         // Do not use target as the delete/create operation will be traced
         if (features != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
squid:S1186 - Methods should not be empty.
squid:S00122 - Statements should be on separate lines.
squid:S1170 - Public constants should be declared "static final" rather than merely "final".
This pull request removes 116 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
https://dev.eclipse.org/sonar/rules/show/squid:S1186
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S1170
Please let me know if you have any questions.
George Kankava