### PR TITLE
Multiple code improvements - squid:S2065, squid:ModifiersOrderCheck, squid:S1226, squid:S1213

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
+++ b/ff4j-core/src/main/java/org/ff4j/conf/XmlParser.java
@@ -677,11 +677,13 @@ public final class XmlParser {
      * @return
      */
     public String escapeXML(String value) {
-        if (value == null) return null;
-        value = value.replaceAll("&", "&amp;");
-        value = value.replaceAll(">", "&gt;");
-        value = value.replaceAll("<", "&lt;");
-        return value;
+        if (value == null) {
+            return null;
+        }
+        
+        return value.replaceAll("&", "&amp;")
+                    .replaceAll(">", "&gt;")
+                    .replaceAll("<", "&lt;");
     }
     
 

--- a/ff4j-core/src/main/java/org/ff4j/core/FlippingExecutionContext.java
+++ b/ff4j-core/src/main/java/org/ff4j/core/FlippingExecutionContext.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class FlippingExecutionContext {
 
     /** Current Parameter Map. */
-    private transient Map<String, Object> parameters = new HashMap<String, Object>();
+    private Map<String, Object> parameters = new HashMap<String, Object>();
 
     /**
      * Default Constructor.

--- a/ff4j-core/src/main/java/org/ff4j/property/multi/AbstractPropertyList.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/multi/AbstractPropertyList.java
@@ -83,7 +83,9 @@ public abstract class AbstractPropertyList < T > extends AbstractPropertyMultiVa
     @Override
     public List<T> fromString(String v) {
         List<T> list = super.fromString(v);
-        if (list == null) return null;
+        if (list == null) {
+            return null;
+        }
         return new ArrayList<T>(list);
     }
 

--- a/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/property/store/JdbcPropertyStore.java
@@ -58,7 +58,7 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
     private JdbcQueryBuilder queryBuilder;
     
     /** Mapper. */
-    private JdbcPropertyMapper JDBC_MAPPER = new JdbcPropertyMapper();
+    private JdbcPropertyMapper jdbcMapper = new JdbcPropertyMapper();
 
     /** Default Constructor. */
     public JdbcPropertyStore() {}
@@ -151,7 +151,7 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
             ps = buildStatement(sqlConn, getQueryBuilder().getProperty(), name);
             rs = ps.executeQuery();
             rs.next();
-            return JDBC_MAPPER.map(rs);
+            return jdbcMapper.map(rs);
         } catch (SQLException sqlEX) {
             throw new PropertyAccessException("Cannot check property existence, error related to database", sqlEX);
         } finally {
@@ -223,7 +223,7 @@ public class JdbcPropertyStore extends AbstractPropertyStore {
             ps = buildStatement(sqlConn, getQueryBuilder().getAllProperties());
             rs = ps.executeQuery();
             while (rs.next()) {
-                Property<?> ap = JDBC_MAPPER.map(rs);
+                Property<?> ap = jdbcMapper.map(rs);
                 properties.put(ap.getName(),ap);
             }
         } catch (SQLException sqlEX) {

--- a/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/mapper/Neo4jMapper.java
+++ b/ff4j-store-neo4j/src/main/java/org/ff4j/neo4j/mapper/Neo4jMapper.java
@@ -80,7 +80,7 @@ public class Neo4jMapper {
      * @return
      *      target flippingStrategy
      */
-    static public FlippingStrategy fromNode2FlippingStrategy(String featureUid, Node nodeFlippingStrategy) {
+    public static FlippingStrategy fromNode2FlippingStrategy(String featureUid, Node nodeFlippingStrategy) {
         Map < String, Object > nodeProperties = nodeFlippingStrategy.getAllProperties();
         HashMap < String, String > initParams = new HashMap<>();
         if (nodeProperties.containsKey(NODESTRATEGY_ATT_INITPARAMS)) {
@@ -107,7 +107,7 @@ public class Neo4jMapper {
      * @return
      *      value of node
      */
-    static public Property<?> fromNode2Property(Node nodeProperty) {
+    public static Property<?> fromNode2Property(Node nodeProperty) {
         Map < String, Object > nodeProperties = nodeProperty.getAllProperties();
         if (!nodeProperties.containsKey(NODEPROPERTY_ATT_NAME)) {
             throw new IllegalArgumentException(NODEPROPERTY_ATT_NAME + " is a required property");

--- a/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
+++ b/ff4j-strategy-drools/src/main/java/org/ff4j/drools/FF4jDroolsService.java
@@ -57,7 +57,7 @@ public final class FF4jDroolsService implements Serializable {
     private static final Logger LOGGER = LoggerFactory.getLogger(FF4jDroolsFlippingStrategy.class);
 
     /** Protected instance. */
-    private static FF4jDroolsService _instance;
+    private static FF4jDroolsService instance;
     
     /** Drools services first level. */
     private KieServices kieServices;
@@ -87,7 +87,7 @@ public final class FF4jDroolsService implements Serializable {
      *      singleton already created.
      */
     public static synchronized boolean isInitialized() {
-        return _instance != null && _instance.ksession != null;
+        return instance != null && instance.ksession != null;
     }
     
     /**
@@ -100,7 +100,7 @@ public final class FF4jDroolsService implements Serializable {
             throw new IllegalStateException("The service has not been initialized yet, "
                     + "please init with initFromBaseName() or initFromRulesFiles()");
         }
-        return _instance;
+        return instance;
     }
     
     /**
@@ -118,13 +118,13 @@ public final class FF4jDroolsService implements Serializable {
         if (isInitialized()) {
             throw new IllegalStateException("This Factory has already be initialized once");
         }
-        _instance               = new FF4jDroolsService();
-        _instance.basename      = baseName; 
-        _instance.kieServices   = KieServices.Factory.get();
-        _instance.kieContainer  = _instance.kieServices.newKieClasspathContainer();
-        _instance.ksession      = _instance.kieContainer.newKieSession(baseName);
+        instance               = new FF4jDroolsService();
+        instance.basename      = baseName; 
+        instance.kieServices   = KieServices.Factory.get();
+        instance.kieContainer  = instance.kieServices.newKieClasspathContainer();
+        instance.ksession      = instance.kieContainer.newKieSession(baseName);
         
-        if (_instance.ksession == null) {
+        if (instance.ksession == null) {
             throw new IllegalArgumentException("Cannot find kName " + baseName + " , check kmodule.xml file.");
         }
     }
@@ -139,8 +139,8 @@ public final class FF4jDroolsService implements Serializable {
         if (isInitialized()) {
             throw new IllegalStateException("This Factory has already be initialized once");
         }
-        _instance               = new FF4jDroolsService();
-        _instance.ruleFiles     = ruleFiles; 
+        instance               = new FF4jDroolsService();
+        instance.ruleFiles     = ruleFiles; 
         
         KieHelper helper = new KieHelper();
         KieSessionConfiguration sessionConfig = KnowledgeBaseFactory.newKnowledgeSessionConfiguration();
@@ -151,7 +151,7 @@ public final class FF4jDroolsService implements Serializable {
             ResourceType typeFile = ResourceType.determineResourceType(drlFile);
             helper.addContent(fileContent, typeFile);
         }
-        _instance.ksession = helper.build(EventProcessingOption.STREAM).newKieSession(sessionConfig, null);
+        instance.ksession = helper.build(EventProcessingOption.STREAM).newKieSession(sessionConfig, null);
     }
     
     /** {@inheritDoc} */
@@ -162,16 +162,16 @@ public final class FF4jDroolsService implements Serializable {
          * 
          * FF4J expects the fact {@link FF4JDroolsRequest} to be modified by the target rules. By default the status is 'false'.
          */
-        _instance.ksession.setGlobal("store", request.getFeatureStore());
+        instance.ksession.setGlobal("store", request.getFeatureStore());
 
         // FactHandle drHandler = ksession.insert(droolsRequest);
-        FactHandle requestHandle = _instance.ksession.insert(request);
+        FactHandle requestHandle = instance.ksession.insert(request);
 
         // Execute the rules
         ksession.fireAllRules();
 
         // clean session, note that retract() is deprecated
-        _instance.ksession.delete(requestHandle);
+        instance.ksession.delete(requestHandle);
         //_instance.ksession.dispose();
 
         LOGGER.debug("Evaluating feature " + request.getFeatureName() + " to " + request.isToggled());        
@@ -186,7 +186,7 @@ public final class FF4jDroolsService implements Serializable {
      * @return
      *      file content as string
      */
-    private final static String loadResourceAsString(final String resourceName) {
+    private static final String loadResourceAsString(final String resourceName) {
         InputStream rin = null;
         try {
             rin = ClassLoader.getSystemResourceAsStream(resourceName);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2065 - Fields in non-serializable classes should not be "transient".
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
squid:S1226 - Method parameters, caught exceptions and foreach variables should not be reassigned.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2065
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1226
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava