### PR TITLE
Multiple code improvements - squid:S1161, squid:ClassVariableVisibilityCheck, squid:S1444, squid:S3008

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/proxy/FeatureStoreAuditProxy.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/proxy/FeatureStoreAuditProxy.java
@@ -117,6 +117,7 @@ public class FeatureStoreAuditProxy implements FeatureStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void removeRoleFromFeature(String uid, String roleName) {
         long start = System.nanoTime();
         target.removeRoleFromFeature(uid, roleName);

--- a/ff4j-core/src/main/java/org/ff4j/audit/proxy/PropertyStoreAuditProxy.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/proxy/PropertyStoreAuditProxy.java
@@ -61,6 +61,7 @@ public class PropertyStoreAuditProxy implements PropertyStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public  < T > void createProperty(Property<T> prop) {
         long start = System.nanoTime();
         target.createProperty(prop);
@@ -72,6 +73,7 @@ public class PropertyStoreAuditProxy implements PropertyStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void updateProperty(String name, String newValue) {
         long start = System.nanoTime();
         target.updateProperty(name, newValue);
@@ -83,6 +85,7 @@ public class PropertyStoreAuditProxy implements PropertyStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public <T> void updateProperty(Property<T> prop) {
         long start = System.nanoTime();
         target.updateProperty(prop);
@@ -94,6 +97,7 @@ public class PropertyStoreAuditProxy implements PropertyStore {
     }
 
     /** {@inheritDoc} */
+    @Override
     public void deleteProperty(String name) {
         long start = System.nanoTime();
         target.deleteProperty(name);
@@ -104,31 +108,37 @@ public class PropertyStoreAuditProxy implements PropertyStore {
     }
     
     /** {@inheritDoc} */
+    @Override
     public boolean existProperty(String name) {
         return target.existProperty(name);
     }
 
     /** {@inheritDoc} */
+    @Override
     public Property<?> readProperty(String name) {
         return target.readProperty(name);
     }
     
     /** {@inheritDoc} */
+    @Override
     public Map<String, Property<?>> readAllProperties() {
         return target.readAllProperties();
     }
 
     /** {@inheritDoc} */
+    @Override
     public Set<String> listPropertyNames() {
         return target.listPropertyNames();
     }
 
     /** {@inheritDoc} */
+    @Override
     public boolean isEmpty() {
         return target.isEmpty();
     }
 
     /** {@inheritDoc} */
+    @Override
     public void clear() {
         long start = System.nanoTime();
         target.clear();
@@ -139,6 +149,7 @@ public class PropertyStoreAuditProxy implements PropertyStore {
     }
     
     /** {@inheritDoc} */
+    @Override
     public void importProperties(Collection<Property<?>> properties) {
         // Do not use target as the delete/create operation will be traced
         if (properties != null) {

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcQueryBuilder.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcQueryBuilder.java
@@ -33,10 +33,10 @@ import static org.ff4j.store.JdbcStoreConstants.*;
 public class JdbcQueryBuilder {
 	
     /** table prefix. */
-	public String tablePrefix = "FF4J_";
+	private String tablePrefix = "FF4J_";
 	
 	/** table suffix. */
-	public String tableSuffix = "";
+	private String tableSuffix = "";
 
 	/** 
 	 * Default constructor. 
@@ -393,5 +393,21 @@ public class JdbcQueryBuilder {
 		sb.append(" AND   (" + COL_EVENT_TIME + "< ?)");
 		return sb.toString();
     }
-	
+
+	public String getTablePrefix() {
+		return tablePrefix;
+	}
+
+	public void setTablePrefix(String tablePrefix) {
+		this.tablePrefix = tablePrefix;
+	}
+
+	public String getTableSuffix() {
+		return tableSuffix;
+	}
+
+	public void setTableSuffix(String tableSuffix) {
+		this.tableSuffix = tableSuffix;
+	}
+
 }

--- a/ff4j-store-redis/src/main/java/org/ff4j/redis/RedisContants.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/redis/RedisContants.java
@@ -43,7 +43,7 @@ public class RedisContants {
     public static final String KEY_EVENT = "FF4J_EVENT_";
     
     /** default ttl. */
-    public static int DEFAULT_TTL = 900000000;
+    public static final int DEFAULT_TTL = 900000000;
     
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:S1444 - "public static" fields should be constant.
squid:S3008 - Static non-final field names should comply with a naming convention.
This pull request removes 120 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:S3008
Please let me know if you have any questions.
George Kankava