### PR TITLE
Multiple code improvements - squid:S1161, squid:S1213, squid:SwitchLastCaseIsDefaultCheck

### DIFF
--- a/ff4j-cli/src/main/java/org/ff4j/cli/ansi/AnsiTerminal.java
+++ b/ff4j-cli/src/main/java/org/ff4j/cli/ansi/AnsiTerminal.java
@@ -115,7 +115,9 @@ public class AnsiTerminal implements AnsiConstants {
                  case SOLARIS:
                      System.out.print(text);
                      System.out.flush();
-                 break;
+                     break;
+                 default:
+                     break;
              }
          }
     }

--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
@@ -75,6 +75,7 @@ public class JdbcEventRepository extends AbstractEventRepository {
     }
     
     /** {@inheritDoc} */
+    @Override
     public int getTotalEventCount() {
         Connection        sqlConn = null;
         PreparedStatement stmt = null;
@@ -98,6 +99,7 @@ public class JdbcEventRepository extends AbstractEventRepository {
     }
 
     /** {@inheritDoc} */
+    @Override
     public boolean saveEvent(Event evt) {
         Util.assertNotNull(evt);
         Util.assertHasLength(evt.getName());
@@ -170,6 +172,7 @@ public class JdbcEventRepository extends AbstractEventRepository {
     }
 
     /** {@inheritDoc} */
+    @Override
     public Set < String > getFeatureNames() {
         Set < String> listOfFeatureNames = new HashSet<String>();
         Connection sqlConn = null;
@@ -194,6 +197,7 @@ public class JdbcEventRepository extends AbstractEventRepository {
     }
     
     /** {@inheritDoc} */
+    @Override
     public PieChart featuresListDistributionPie(long startTime, long endTime) {
         PieChart pieGraph = new PieChart(TITLE_PIE_HITCOUNT);
         Connection sqlConn = null;
@@ -232,6 +236,7 @@ public class JdbcEventRepository extends AbstractEventRepository {
     }
     
     /** {@inheritDoc} */
+    @Override
     public BarChart getFeaturesUsageOverTime(Set<String> featNameSet, long startTime, long endTime, int nbslot) {
         
         // Build Labels
@@ -277,6 +282,7 @@ public class JdbcEventRepository extends AbstractEventRepository {
     }
 
     /** {@inheritDoc} */
+    @Override
     public PieChart featureDistributionPie(String featureId, long startTime, long endTime) {
         PieChart pieGraph = new PieChart("Hits Count for " + featureId);
         

--- a/ff4j-store-redis/src/main/java/org/ff4j/redis/RedisContants.java
+++ b/ff4j-store-redis/src/main/java/org/ff4j/redis/RedisContants.java
@@ -27,12 +27,6 @@ package org.ff4j.redis;
  */
 public class RedisContants {
     
-    /**
-     * Hide contructor for constants.
-     */
-    private RedisContants() {
-    }
-    
     /** prefix of keys. */
     public static final String KEY_FEATURE = "FF4J_FEATURE_";
     
@@ -45,5 +39,9 @@ public class RedisContants {
     /** default ttl. */
     public static int DEFAULT_TTL = 900000000;
     
-
+    /**
+     * Hide contructor for constants.
+     */
+    private RedisContants() {
+    }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1161 - "@Override" annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
This pull request removes 55 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava