### PR TITLE
Restore autoCommit setting after transactions

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -213,6 +213,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
     	assertFeatureNotNull(fp);
     	Connection sqlConn = null;
         PreparedStatement ps = null;
+        Boolean previousAutoCommit = null;
         try {
 
             // Create connection
@@ -222,6 +223,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
             }
 
             // Begin TX
+            previousAutoCommit = sqlConn.getAutoCommit();
             sqlConn.setAutoCommit(false);
 
             // Create feature
@@ -269,7 +271,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
             throw new FeatureAccessException(CANNOT_UPDATE_FEATURES_DATABASE_SQL_ERROR, sqlEX);
         } finally {
             closeStatement(ps);
-            closeConnection(sqlConn);
+            closeConnection(sqlConn, previousAutoCommit);
         }
     }
 
@@ -279,9 +281,11 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
     	assertFeatureExist(uid);
         Connection sqlConn = null;
         PreparedStatement ps = null;
+        Boolean previousAutoCommit = null;
         try {
             // Create connection
             sqlConn = getDataSource().getConnection();
+            previousAutoCommit = sqlConn.getAutoCommit();
             sqlConn.setAutoCommit(false);
             Feature fp = read(uid);
 
@@ -324,7 +328,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
             throw new FeatureAccessException(CANNOT_UPDATE_FEATURES_DATABASE_SQL_ERROR, sqlEX);
         } finally {
             closeStatement(ps);
-            closeConnection(sqlConn);
+            closeConnection(sqlConn, previousAutoCommit);
         }
     }
 
@@ -534,11 +538,13 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
 
         Connection sqlConn = null;
         PreparedStatement ps = null;
+        Boolean previousAutoCommit = null;
 
         try {
             sqlConn = dataSource.getConnection();
 
             // Begin TX
+            previousAutoCommit = sqlConn.getAutoCommit();
             sqlConn.setAutoCommit(false);
 
             // Queries
@@ -555,7 +561,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
             throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeStatement(ps);
-            closeConnection(sqlConn);
+            closeConnection(sqlConn, previousAutoCommit);
         }
     }
 

--- a/ff4j-core/src/main/java/org/ff4j/utils/JdbcUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/JdbcUtils.java
@@ -164,26 +164,40 @@ public class JdbcUtils {
     }
     
     /**
-     * Return connection to pool.
+     * Restore previous <code>autoCommit</code> setting and return connection to pool.
      *
      * @param sqlConnection
+     * @param previousAutoCommit original <code>autoCommit</code> setting of <code>sqlConnection</code>. Ignored when <code>
+     *                           null</code>
      */
-    public static void closeConnection(Connection sqlConnection) {
+    public static void closeConnection(Connection sqlConnection, Boolean previousAutoCommit) {
         try {
             if (sqlConnection != null && !sqlConnection.isClosed()) {
+                if (previousAutoCommit != null) {
+                    sqlConnection.setAutoCommit(previousAutoCommit);
+                }
                 sqlConnection.close();
             }
         } catch (SQLException e) {
             throw new FeatureAccessException("An error occur when closing statement", e);
         }
     }
-    
+
     /**
-     * Utility method to perform rollback in correct way.
-     * 
-     * @param sqlConn
-     *            current sql connection
+     * Return connection to pool.
+     *
+     * @param sqlConnection
      */
+    public static void closeConnection(Connection sqlConnection) {
+        closeConnection(sqlConnection, null);
+    }
+
+     /**
+      * Utility method to perform rollback in correct way.
+      *
+      * @param sqlConn
+      *            current sql connection
+      */
     public static void rollback(Connection sqlConn) {
         try {
             if (sqlConn != null && !sqlConn.isClosed()) {


### PR DESCRIPTION
`JdbcFeatureStore` overrides the `autoCommit` setting of the SQL `Connection` in order to handle its own transactions. However, it did not restore the previous value afterwards. As a consequence, feature toggle settings had not been stored immediately after their creation (because `autoCommit` had remained `false`. Only after a restart had the values been stored.

By restoring the previous `autoCommit` value changed feature toggle settings are stored now correctly.