### PR TITLE
Exclude logback.xml in jar packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -827,6 +827,9 @@
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${version.maven.plugin.jar}</version>
                     <configuration>
+                        <excludes>
+                            <exclude>**/logback.xml</exclude>
+                        </excludes>
                         <archive>
                             <manifest>
                                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>


### PR DESCRIPTION
The ```logback.xml``` file should not be packaged into the jar artifacts, as it will pollute or override settings of projects using ff4j (this happened to us).