### PR TITLE
Update JdbcUtils.java

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/utils/JdbcUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/JdbcUtils.java
@@ -108,7 +108,7 @@ public class JdbcUtils {
         PreparedStatement ps = sqlConn.prepareStatement(query);
         if (params != null && params.length > 0) {
             for (int i = 0; i < params.length; i++) {
-                ps.setString(i + 1, params[i]);
+                ps.setObject(i + 1, params[i]);
             }
         }
         return ps;


### PR DESCRIPTION
setObject should be used since the column enable is integer and not a string. JDBC will handle the type conversion.