### PR TITLE
Issue 199 - Close property dialog and return to feature dialog

### DIFF
--- a/ff4j-web/src/main/resources/views/view-modal-properties.html
+++ b/ff4j-web/src/main/resources/views/view-modal-properties.html
@@ -335,7 +335,7 @@
     $(document).ready(function() {
         $('#updatePropertyForm').on('submit', function(e) {
             // do something
-            var featId = $(".modal-body #featureid").val();
+            var featId = $("#updatePropertyForm").find(".modal-body #featureid").val();
             if(featId == "" || featId == null) {
                 e.submit();
             } else {


### PR DESCRIPTION
When editing and saving a property attached to a feature, the property dialog was closing and the page was immediately redirecting to the properties tab.    It looks like the featureId was being retrieved from the wrong modal.