### PR TITLE
Fix the character encoding problems in ff4j-web

### DIFF
--- a/ff4j-web/src/main/java/org/ff4j/web/FF4jDispatcherServlet.java
+++ b/ff4j-web/src/main/java/org/ff4j/web/FF4jDispatcherServlet.java
@@ -1,5 +1,7 @@
 package org.ff4j.web;
 
+import org.ff4j.web.bean.WebConstants;
+
 import static org.ff4j.web.bean.WebConstants.VIEW_404;
 import static org.ff4j.web.bean.WebConstants.VIEW_API;
 import static org.ff4j.web.bean.WebConstants.VIEW_DEFAULT;
@@ -44,6 +46,7 @@ public class FF4jDispatcherServlet extends FF4jServlet {
     /** {@inheritDoc} */
     public void doGet(HttpServletRequest req, HttpServletResponse res)
     throws ServletException, IOException {
+        res.setCharacterEncoding(WebConstants.UTF8_ENCODING);
         
     	String targetView  = getTargetView(req);
 
@@ -66,6 +69,8 @@ public class FF4jDispatcherServlet extends FF4jServlet {
     /** {@inheritDoc} */
     public void doPost(HttpServletRequest req, HttpServletResponse res)
     throws ServletException, IOException {
+        res.setCharacterEncoding(WebConstants.UTF8_ENCODING);
+
         String targetView = getTargetView(req);
         
         if (VIEW_API.equals(targetView)) {


### PR DESCRIPTION
If a user input in the Feature Name or Description, Property Name, Property Value multi-byte characters like `日本語` they are not properly encoded.

![old](https://cloud.githubusercontent.com/assets/37051/24089160/be682a88-0d76-11e7-9eae-ca8c98c05d10.gif)


Fixed:
![new](https://cloud.githubusercontent.com/assets/37051/24089165/cd8122e0-0d76-11e7-8c78-edd9755f6b87.gif)



