### PR TITLE
Fix "Lock wait timeout exceeded; try restarting transaction"

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
+++ b/ff4j-core/src/main/java/org/ff4j/audit/repository/JdbcEventRepository.java
@@ -19,6 +19,7 @@ import static org.ff4j.utils.JdbcUtils.closeResultSet;
 import static org.ff4j.utils.JdbcUtils.closeStatement;
 import static org.ff4j.utils.JdbcUtils.executeUpdate;
 import static org.ff4j.utils.JdbcUtils.isTableExist;
+import static org.ff4j.utils.JdbcUtils.rollback;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -144,10 +145,10 @@ public class JdbcEventRepository extends AbstractEventRepository {
             
             // Commit TX
             sqlConn.commit();
-            
+
         } catch(Exception exc) {
+            rollback(sqlConn);
             throw new AuditAccessException("Cannot insert event into DB (" + exc.getClass() + ") "+ exc.getCause(), exc);
-            
         } finally {
            closeStatement(stmt);
            closeConnection(sqlConn);

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -558,6 +558,7 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
             sqlConn.commit();
 
         } catch (SQLException sqlEX) {
+            rollback(sqlConn);
             throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
         } finally {
             closeStatement(ps);

--- a/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
+++ b/ff4j-core/src/main/java/org/ff4j/store/JdbcFeatureStore.java
@@ -480,16 +480,21 @@ public class JdbcFeatureStore extends AbstractFeatureStore {
             ps = sqlConn.prepareStatement(getQueryBuilder().deleteAllFeatureCustomProperties());
             ps.setString(1, fpExist.getUid());
             ps.executeUpdate();
+            closeStatement(ps);
+            ps = null;
 
-            // CREATE PROPERTIES
-            createCustomProperties(fp.getUid(), fp.getCustomProperties().values());
-           
-            } catch (SQLException sqlEX) {
-                throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
-            } finally {
+            // CREATE CUSTOM PROPERTIES
+            for (Property property : fp.getCustomProperties().values()) {
+                ps = createCustomProperty(sqlConn, fp.getUid(), property);
                 closeStatement(ps);
-                closeConnection(sqlConn);
+                ps = null;
             }
+        } catch (SQLException sqlEX) {
+            throw new FeatureAccessException(CANNOT_CHECK_FEATURE_EXISTENCE_ERROR_RELATED_TO_DATABASE, sqlEX);
+        } finally {
+            closeStatement(ps);
+            closeConnection(sqlConn);
+        }
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
If you use JdbcFeatureStore with "audit" enabled, you can not add properties to the feature on `ff4j-web Administration Console`.
"Lock wait timeout exceeded; try restarting transaction" Occurs.
If "audit" is set to disabled, this problem does not occur.

![lock wait timeout](https://cloud.githubusercontent.com/assets/37051/24318409/23a09ab4-1148-11e7-8802-908fbbd29281.gif)
