### PR TITLE
Fix to allow binding of multiple parameters separated by semicolon

### DIFF
--- a/ff4j-web/src/main/resources/static/js/ff4j.js
+++ b/ff4j-web/src/main/resources/static/js/ff4j.js
@@ -130,12 +130,17 @@ function ff4j_updateModalEditFeature(uid) {
       if (feature.flippingStrategy) {
    	   $("#modalEdit #stratlist").show();
    	   $("#modalEdit #strategy").val(feature.flippingStrategy.type);
+
+   	   var initParamsStr = '';
    	   for (var key in feature.flippingStrategy.initParams) {
    	    if (feature.flippingStrategy.initParams.hasOwnProperty(key)) {
-   		     //console.log(key + " -> " + feature.flippingStrategy.initParams[key]);
-   		     $("#modalEdit #initParams").val(key + '=' + feature.flippingStrategy.initParams[key]);
+   	     if (initParamsStr.length > 0) {
+   	      initParamsStr+= ';';
+   	     }
+   	     initParamsStr+= (key + '=' + feature.flippingStrategy.initParams[key]);
    		}
-   	  } 
+   	   }
+   	   $("#modalEdit #initParams").val(initParamsStr);
       } else {
    	   $("#modalEdit #stratlist").hide();
    	   $("#modalEdit #strategy").val('');


### PR DESCRIPTION
Fix to allow binding of multiple parameters separated by semicolon when opening feature edit dialog on ff4j-web Administration Console.

Now I can save multiple parameters, but opening a modal to edit again has the problem that only one parameter is bound.

<img width="972" alt="ff4j-feature-edit" src="https://cloud.githubusercontent.com/assets/37051/24319053/a8988568-1154-11e7-95bd-82fa52ae587a.png">
