### PR TITLE
Bump store-hazelcast parent pom version to 1.6.6-SNAPSHOT

### DIFF
--- a/ff4j-store-hazelcast/pom.xml
+++ b/ff4j-store-hazelcast/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.ff4j</groupId>
 		<artifactId>ff4j-parent</artifactId>
-		<version>1.6.5-SNAPSHOT</version>
+		<version>1.6.6-SNAPSHOT</version>
 	</parent>
 
 	<!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->


### PR DESCRIPTION
For some reason the store-hazelcast subproject was pegged to ff4j-parent:1.6.5-SNAPSHOT, and not 1.6.6-SNAPSHOT, which is what the rest of the project is on. I've bumped it to be consistent with the rest of the project, so that I can continue building on master.