### PR TITLE
PostgreSQL stores unquoted SQL identifiers in lower case

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/utils/JdbcUtils.java
+++ b/ff4j-core/src/main/java/org/ff4j/utils/JdbcUtils.java
@@ -57,6 +57,9 @@ public class JdbcUtils {
         try {
             sqlConn = ds.getConnection();
             DatabaseMetaData dbmd = sqlConn.getMetaData();
+            if (dbmd.storesLowerCaseIdentifiers()) {
+                tableName = tableName.toLowerCase();
+            }
             rs = dbmd.getTables(null, null, tableName, new String[] {"TABLE"});
             return rs.next();
         } catch (SQLException sqlEX) {


### PR DESCRIPTION
PostgreSQL treats mixed case unquoted SQL identifiers as case insensitive and stores them in lower case.

Because of that, `isTableExists` returns false, although the table was created before with `createSchema`.

https://docs.oracle.com/javase/9/docs/api/java/sql/DatabaseMetaData.html#storesLowerCaseIdentifiers--