### PR TITLE
extends Serializable otherwise hazelcast implementation is failing

### DIFF
--- a/ff4j-core/src/main/java/org/ff4j/core/FlippingStrategy.java
+++ b/ff4j-core/src/main/java/org/ff4j/core/FlippingStrategy.java
@@ -1,5 +1,6 @@
 package org.ff4j.core;
 
+import java.io.Serializable;
 import java.util.Map;
 
 /*
@@ -27,7 +28,7 @@ import java.util.Map;
  * 
  * @author Cedrick Lunven (@clunven)
  */
-public interface FlippingStrategy {
+public interface FlippingStrategy extends Serializable {
 
     /**
      * Allow to parameterized Flipping Strategy


### PR DESCRIPTION
Hazelcast object depends on Serialization process and without Serializable  all operation related to Strategy is failing in hazelcast